### PR TITLE
Add backend-backed Spotify OAuth login

### DIFF
--- a/matchify-app/src/__tests__/hooks/use-spotify-login.test.ts
+++ b/matchify-app/src/__tests__/hooks/use-spotify-login.test.ts
@@ -1,0 +1,108 @@
+/* eslint-disable import/first, @typescript-eslint/no-require-imports */
+
+process.env.EXPO_PUBLIC_SPOTIFY_CLIENT_ID = 'spotify-client-id'
+process.env.EXPO_PUBLIC_API_URL = 'http://localhost:8000'
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn().mockResolvedValue(null),
+  setItemAsync: jest.fn().mockResolvedValue(undefined),
+  deleteItemAsync: jest.fn().mockResolvedValue(undefined),
+}))
+
+const mockPromptAsync = jest.fn()
+let mockAuthResponse: unknown = null
+
+jest.mock('expo-auth-session', () => ({
+  ResponseType: { Code: 'code' },
+  makeRedirectUri: jest.fn(() => 'matchify://redirect'),
+  useAuthRequest: jest.fn(() => [{}, mockAuthResponse, mockPromptAsync]),
+}))
+
+jest.mock('expo-web-browser', () => ({
+  maybeCompleteAuthSession: jest.fn(),
+}))
+
+const mockExecuteLogin = jest.fn()
+
+jest.mock('urql', () => ({
+  gql: jest.fn((strings: TemplateStringsArray) => strings.join('')),
+  useMutation: jest.fn(() => [{ fetching: false }, mockExecuteLogin]),
+}))
+
+import { act, renderHook, waitFor } from '@testing-library/react-native'
+
+const { useSpotifyLogin } = require('@/hooks/use-spotify-login')
+const { useAuthStore } = require('@/store/auth-store')
+
+beforeEach(() => {
+  mockAuthResponse = null
+  mockPromptAsync.mockReset()
+  mockExecuteLogin.mockReset()
+  useAuthStore.setState({
+    status: 'unauthenticated',
+    accessToken: null,
+    refreshToken: null,
+    expiresAt: null,
+    user: null,
+  })
+})
+
+describe('useSpotifyLogin', () => {
+  it('exchanges a successful Spotify auth code through the backend login mutation', async () => {
+    mockExecuteLogin.mockResolvedValue({
+      data: {
+        loginWithSpotify: {
+          token: 'jwt-token',
+          user: {
+            id: 'user-id',
+            displayName: 'Daria',
+            profileImageUrl: 'https://example.com/avatar.jpg',
+          },
+        },
+      },
+    })
+
+    const { rerender, result } = renderHook(() => useSpotifyLogin())
+
+    act(() => {
+      mockAuthResponse = {
+        type: 'success',
+        params: { code: 'spotify-code' },
+      }
+      rerender({})
+    })
+
+    await waitFor(() => {
+      expect(mockExecuteLogin).toHaveBeenCalledWith({
+        code: 'spotify-code',
+        redirectUri: 'matchify://redirect',
+      })
+    })
+
+    expect(useAuthStore.getState()).toEqual(
+      expect.objectContaining({
+        status: 'authenticated',
+        accessToken: 'jwt-token',
+        refreshToken: '',
+        user: {
+          id: 'user-id',
+          displayName: 'Daria',
+          imageUrl: 'https://example.com/avatar.jpg',
+        },
+      })
+    )
+    expect(result.current.error).toBeNull()
+  })
+
+  it('reports cancelled OAuth attempts to the caller', () => {
+    const { rerender, result } = renderHook(() => useSpotifyLogin())
+
+    act(() => {
+      mockAuthResponse = { type: 'cancel' }
+      rerender({})
+    })
+
+    expect(result.current.error).toBe('Spotify login was cancelled.')
+    expect(mockExecuteLogin).not.toHaveBeenCalled()
+  })
+})

--- a/matchify-app/src/hooks/use-spotify-login.ts
+++ b/matchify-app/src/hooks/use-spotify-login.ts
@@ -1,106 +1,157 @@
-import { useState, useEffect } from "react";
-import * as AuthSession from "expo-auth-session";
-import * as WebBrowser from "expo-web-browser";
-import { useAuthStore } from "@/store/auth-store";
-import type { SpotifyUser } from "@/store/auth-store";
+import { useCallback, useEffect, useState } from 'react'
+import * as AuthSession from 'expo-auth-session'
+import * as WebBrowser from 'expo-web-browser'
+import { gql, useMutation } from 'urql'
 
-WebBrowser.maybeCompleteAuthSession();
+import { useAuthStore } from '@/store/auth-store'
+import type { SpotifyUser } from '@/store/auth-store'
 
-const CLIENT_ID = process.env.EXPO_PUBLIC_SPOTIFY_CLIENT_ID;
-if (!CLIENT_ID)
-  throw new Error("EXPO_PUBLIC_SPOTIFY_CLIENT_ID is not set in .env.local");
+WebBrowser.maybeCompleteAuthSession()
+
+const CLIENT_ID = process.env.EXPO_PUBLIC_SPOTIFY_CLIENT_ID
+if (!CLIENT_ID) {
+  throw new Error('EXPO_PUBLIC_SPOTIFY_CLIENT_ID is not set in .env.local')
+}
 
 const DISCOVERY: AuthSession.DiscoveryDocument = {
-  authorizationEndpoint: "https://accounts.spotify.com/authorize",
-  tokenEndpoint: "https://accounts.spotify.com/api/token",
-};
+  authorizationEndpoint: 'https://accounts.spotify.com/authorize',
+  tokenEndpoint: 'https://accounts.spotify.com/api/token',
+}
+
+const LOGIN_WITH_SPOTIFY_MUTATION = gql`
+  mutation LoginWithSpotify($code: String!, $redirectUri: String!) {
+    loginWithSpotify(code: $code, redirectUri: $redirectUri) {
+      token
+      user {
+        id
+        displayName
+        profileImageUrl
+      }
+    }
+  }
+`
+
+const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000
+
+interface LoginWithSpotifyData {
+  loginWithSpotify: {
+    token: string
+    user: {
+      id: string
+      displayName: string
+      profileImageUrl: string | null
+    }
+  }
+}
+
+interface LoginWithSpotifyVariables {
+  code: string
+  redirectUri: string
+}
 
 export function useSpotifyLogin() {
-  const setSession = useAuthStore((s) => s.setSession);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const setSession = useAuthStore((s) => s.setSession)
+  const [loginState, executeLogin] = useMutation<
+    LoginWithSpotifyData,
+    LoginWithSpotifyVariables
+  >(LOGIN_WITH_SPOTIFY_MUTATION)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   const redirectUri = AuthSession.makeRedirectUri({
-    scheme: "matchify",
-    path: "redirect",
-  });
+    scheme: 'matchify',
+    path: 'redirect',
+  })
 
   const [request, response, promptAsync] = AuthSession.useAuthRequest(
     {
       clientId: CLIENT_ID!,
-      scopes: ["user-read-private", "user-read-email"],
-      usePKCE: true,
+      scopes: ['user-read-email', 'playlist-modify-public', 'playlist-modify-private'],
       redirectUri,
+      responseType: AuthSession.ResponseType.Code,
+      usePKCE: false,
     },
-    DISCOVERY,
-  );
+    DISCOVERY
+  )
+
+  const completeLogin = useCallback(
+    async (code: string) => {
+      try {
+        const result = await executeLogin({ code, redirectUri })
+
+        if (result.error) {
+          throw new Error(result.error.message)
+        }
+
+        const payload = result.data?.loginWithSpotify
+        if (!payload) {
+          throw new Error('Spotify login did not return a session.')
+        }
+
+        const user: SpotifyUser = {
+          id: String(payload.user.id),
+          displayName: payload.user.displayName,
+          imageUrl: payload.user.profileImageUrl,
+        }
+
+        setSession(payload.token, '', Date.now() + SESSION_TTL_MS, user)
+        setError(null)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Spotify login failed.')
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [executeLogin, redirectUri, setSession]
+  )
 
   useEffect(() => {
-    if (!response) return;
-    if (response.type === "success") {
-      exchangeCodeForSession(response.params.code);
-    } else if (response.type === "error") {
-      setError(response.error?.message ?? "Authentication failed");
-      setIsLoading(false);
-    } else {
-      // cancelled or dismissed
-      setIsLoading(false);
+    if (!response) return
+
+    if (response.type === 'success') {
+      const code = response.params.code
+
+      if (!code) {
+        setError('Spotify did not return an authorization code.')
+        setIsLoading(false)
+        return
+      }
+
+      completeLogin(code)
+      return
     }
-  }, [response]);
 
-  async function exchangeCodeForSession(code: string) {
-    if (!request?.codeVerifier) {
-      setError("Authentication request not initialized");
-      setIsLoading(false);
-      return;
+    if (response.type === 'error') {
+      setError(response.error?.message ?? 'Spotify login failed.')
+      setIsLoading(false)
+      return
     }
-    try {
-      const tokenRes = await fetch("https://accounts.spotify.com/api/token", {
-        method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        body: new URLSearchParams({
-          grant_type: "authorization_code",
-          code,
-          redirect_uri: redirectUri,
-          client_id: CLIENT_ID!,
-          code_verifier: request.codeVerifier,
-        }).toString(),
-      });
-      if (!tokenRes.ok)
-        throw new Error(`Token exchange failed: ${tokenRes.status}`);
-      const tokens = await tokenRes.json();
 
-      const profileRes = await fetch("https://api.spotify.com/v1/me", {
-        headers: { Authorization: `Bearer ${tokens.access_token}` },
-      });
-      if (!profileRes.ok)
-        throw new Error(`Profile fetch failed: ${profileRes.status}`);
-      const profile = await profileRes.json();
-
-      const user: SpotifyUser = {
-        id: profile.id,
-        displayName: profile.display_name ?? profile.id,
-        imageUrl: profile.images?.[0]?.url ?? null,
-      };
-
-      setSession(
-        tokens.access_token,
-        tokens.refresh_token ?? "",
-        Date.now() + tokens.expires_in * 1000,
-        user,
-      );
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Login failed");
-    } finally {
-      setIsLoading(false);
+    if (response.type === 'cancel' || response.type === 'dismiss') {
+      setError('Spotify login was cancelled.')
+      setIsLoading(false)
     }
+  }, [completeLogin, response])
+
+  const login = useCallback(() => {
+    if (!request) {
+      setError('Spotify login is not ready yet.')
+      return
+    }
+
+    setIsLoading(true)
+    setError(null)
+    promptAsync().catch((err: unknown) => {
+      setError(err instanceof Error ? err.message : 'Could not open Spotify login.')
+      setIsLoading(false)
+    })
+  }, [promptAsync, request])
+
+  return {
+    login,
+    isLoading: isLoading || loginState.fetching,
+    error,
+    ready: !!request,
+    redirectUri,
   }
-
-  const login = () => {
-    setIsLoading(true);
-    setError(null);
-    promptAsync();
-  };
-
-  return { login, isLoading, error, ready: !!request };
 }


### PR DESCRIPTION
## Summary
- Switch the Spotify login hook to `expo-auth-session` code flow with the `matchify` redirect URI.
- Send successful auth codes to the `loginWithSpotify` urql mutation instead of exchanging tokens client-side.
- Surface cancel and error states back to the UI, and cover the flow with hook tests.

## Testing
- Added unit tests for successful auth-code exchange and cancelled login handling.
- Local validation passed with the app test suite and TypeScript compile.