### PR TITLE
Add playlist bottom sheets

### DIFF
--- a/matchify-app/src/__tests__/components/glass-input.test.tsx
+++ b/matchify-app/src/__tests__/components/glass-input.test.tsx
@@ -1,0 +1,29 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+
+import { fireEvent, render } from '@testing-library/react-native'
+
+import { GlassInput } from '@/components/ui/glass-input'
+import { Colors } from '@/constants/theme'
+
+jest.mock('@/components/glass-surface', () => {
+  const { View } = require('react-native')
+
+  return {
+    GlassSurface: jest.fn(({ children, ...props }) => <View {...props}>{children}</View>),
+  }
+})
+
+describe('GlassInput', () => {
+  it('uses the accent border while focused', () => {
+    const { getByPlaceholderText, getByTestId } = render(
+      <GlassInput testID="name-input" placeholder="Name" value="" onChangeText={jest.fn()} />
+    )
+
+    fireEvent(getByPlaceholderText('Name'), 'focus')
+
+    expect(getByTestId('name-input-shell')).toHaveStyle({
+      borderColor: Colors.accent,
+      borderWidth: 1.5,
+    })
+  })
+})

--- a/matchify-app/src/__tests__/screens/create-playlist-screen.test.tsx
+++ b/matchify-app/src/__tests__/screens/create-playlist-screen.test.tsx
@@ -1,0 +1,83 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+
+import { fireEvent, render, waitFor } from '@testing-library/react-native'
+import { SafeAreaProvider } from 'react-native-safe-area-context'
+
+const mockBack = jest.fn()
+const mockReplace = jest.fn()
+const mockExecuteMutation = jest.fn()
+const mockUseMutation = jest.fn()
+const mockClient = {
+  query: jest.fn(() => ({ toPromise: jest.fn(() => Promise.resolve({})) })),
+}
+
+jest.mock('expo-router', () => ({
+  router: {
+    back: () => mockBack(),
+    replace: (href: string) => mockReplace(href),
+  },
+}))
+
+jest.mock('urql', () => ({
+  gql: jest.fn((strings: TemplateStringsArray) => strings.join('')),
+  useClient: () => mockClient,
+  useMutation: (mutation: unknown) => mockUseMutation(mutation),
+}))
+
+jest.mock('@/components/glass-surface', () => {
+  const { View } = require('react-native')
+
+  return {
+    GlassSurface: jest.fn(({ children, ...props }) => <View {...props}>{children}</View>),
+  }
+})
+
+const CreatePlaylistScreen = require('@/app/(tabs)/playlists/create').default
+
+const renderScreen = () =>
+  render(
+    <SafeAreaProvider initialMetrics={{ frame: { x: 0, y: 0, width: 390, height: 844 }, insets: { top: 0, right: 0, bottom: 34, left: 0 } }}>
+      <CreatePlaylistScreen />
+    </SafeAreaProvider>
+  )
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockExecuteMutation.mockResolvedValue({
+    data: { createPlaylist: { id: 'playlist-new' } },
+  })
+  mockUseMutation.mockReturnValue([{ fetching: false }, mockExecuteMutation])
+})
+
+describe('CreatePlaylistScreen', () => {
+  it('shows an inline error when name is empty', async () => {
+    const { getByText } = renderScreen()
+
+    fireEvent.press(getByText('Create playlist'))
+
+    expect(getByText('Name is required.')).toBeTruthy()
+    expect(mockExecuteMutation).not.toHaveBeenCalled()
+  })
+
+  it('creates a playlist, refreshes MyPlaylists, and navigates to detail', async () => {
+    const { getByPlaceholderText, getByText } = renderScreen()
+
+    fireEvent.changeText(getByPlaceholderText('Name'), 'Friday Room')
+    fireEvent.changeText(getByPlaceholderText('Description'), 'After work picks')
+    fireEvent.changeText(getByPlaceholderText('Vote threshold'), '3')
+    fireEvent.press(getByText('Create playlist'))
+
+    await waitFor(() => {
+      expect(mockExecuteMutation).toHaveBeenCalledWith({
+        input: {
+          name: 'Friday Room',
+          description: 'After work picks',
+          voteThreshold: 3,
+        },
+      })
+    })
+    expect(mockClient.query).toHaveBeenCalledWith(expect.stringContaining('MyPlaylists'), {}, { requestPolicy: 'network-only' })
+    expect(mockBack).toHaveBeenCalled()
+    expect(mockReplace).toHaveBeenCalledWith('/playlists/playlist-new')
+  })
+})

--- a/matchify-app/src/__tests__/screens/join-playlist-screen.test.tsx
+++ b/matchify-app/src/__tests__/screens/join-playlist-screen.test.tsx
@@ -1,0 +1,85 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+
+import { fireEvent, render, waitFor } from '@testing-library/react-native'
+import { SafeAreaProvider } from 'react-native-safe-area-context'
+
+const mockBack = jest.fn()
+const mockReplace = jest.fn()
+const mockExecuteMutation = jest.fn()
+const mockUseMutation = jest.fn()
+const mockClient = {
+  query: jest.fn(() => ({ toPromise: jest.fn(() => Promise.resolve({})) })),
+}
+
+jest.mock('expo-router', () => ({
+  router: {
+    back: () => mockBack(),
+    replace: (href: string) => mockReplace(href),
+  },
+}))
+
+jest.mock('urql', () => ({
+  gql: jest.fn((strings: TemplateStringsArray) => strings.join('')),
+  useClient: () => mockClient,
+  useMutation: (mutation: unknown) => mockUseMutation(mutation),
+}))
+
+jest.mock('@/components/glass-surface', () => {
+  const { View } = require('react-native')
+
+  return {
+    GlassSurface: jest.fn(({ children, ...props }) => <View {...props}>{children}</View>),
+  }
+})
+
+const JoinPlaylistScreen = require('@/app/(tabs)/playlists/join').default
+
+const renderScreen = () =>
+  render(
+    <SafeAreaProvider initialMetrics={{ frame: { x: 0, y: 0, width: 390, height: 844 }, insets: { top: 0, right: 0, bottom: 34, left: 0 } }}>
+      <JoinPlaylistScreen />
+    </SafeAreaProvider>
+  )
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockExecuteMutation.mockResolvedValue({
+    data: { joinPlaylist: { id: 'playlist-joined' } },
+  })
+  mockUseMutation.mockReturnValue([{ fetching: false }, mockExecuteMutation])
+})
+
+describe('JoinPlaylistScreen', () => {
+  it('uppercases invite codes while typing', () => {
+    const { getByPlaceholderText } = renderScreen()
+    const input = getByPlaceholderText('Invite code')
+
+    fireEvent.changeText(input, 'ab12cd')
+
+    expect(input.props.value).toBe('AB12CD')
+  })
+
+  it('shows an inline error when invite code length is invalid', () => {
+    const { getByPlaceholderText, getByText } = renderScreen()
+
+    fireEvent.changeText(getByPlaceholderText('Invite code'), 'ABC')
+    fireEvent.press(getByText('Join playlist'))
+
+    expect(getByText('Invite code must be 6-8 characters.')).toBeTruthy()
+    expect(mockExecuteMutation).not.toHaveBeenCalled()
+  })
+
+  it('joins a playlist, refreshes MyPlaylists, and navigates to detail', async () => {
+    const { getByPlaceholderText, getByText } = renderScreen()
+
+    fireEvent.changeText(getByPlaceholderText('Invite code'), 'room202')
+    fireEvent.press(getByText('Join playlist'))
+
+    await waitFor(() => {
+      expect(mockExecuteMutation).toHaveBeenCalledWith({ inviteCode: 'ROOM202' })
+    })
+    expect(mockClient.query).toHaveBeenCalledWith(expect.stringContaining('MyPlaylists'), {}, { requestPolicy: 'network-only' })
+    expect(mockBack).toHaveBeenCalled()
+    expect(mockReplace).toHaveBeenCalledWith('/playlists/playlist-joined')
+  })
+})

--- a/matchify-app/src/app/(tabs)/playlists/_layout.tsx
+++ b/matchify-app/src/app/(tabs)/playlists/_layout.tsx
@@ -5,6 +5,8 @@ export default function PlaylistsLayout() {
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="index" />
       <Stack.Screen name="[id]" />
+      <Stack.Screen name="create" />
+      <Stack.Screen name="join" />
     </Stack>
   )
 }

--- a/matchify-app/src/app/(tabs)/playlists/create.tsx
+++ b/matchify-app/src/app/(tabs)/playlists/create.tsx
@@ -1,0 +1,177 @@
+import { useState, type ReactNode } from 'react'
+import { StyleSheet, View } from 'react-native'
+import { router } from 'expo-router'
+import { gql, useClient, useMutation } from 'urql'
+
+import { BottomSheet } from '@/components/ui/bottom-sheet'
+import { GlassInput } from '@/components/ui/glass-input'
+import { PrimaryButton } from '@/components/ui/primary-button'
+import { ThemedText } from '@/components/themed-text'
+import { Colors, Spacing } from '@/constants/theme'
+import { refreshMyPlaylists } from '@/lib/graphql/playlists'
+
+const CREATE_PLAYLIST_MUTATION = gql`
+  mutation CreatePlaylist($input: CreatePlaylistInput!) {
+    createPlaylist(input: $input) {
+      id
+    }
+  }
+`
+
+type CreatePlaylistData = {
+  createPlaylist: {
+    id: string
+  }
+}
+
+type CreatePlaylistVariables = {
+  input: {
+    name: string
+    description?: string | null
+    voteThreshold?: number | null
+  }
+}
+
+export default function CreatePlaylistScreen() {
+  const client = useClient()
+  const [{ fetching }, executeCreate] = useMutation<CreatePlaylistData, CreatePlaylistVariables>(CREATE_PLAYLIST_MUTATION)
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [voteThreshold, setVoteThreshold] = useState('')
+  const [nameError, setNameError] = useState<string | null>(null)
+  const [thresholdError, setThresholdError] = useState<string | null>(null)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const submit = async () => {
+    const trimmedName = name.trim()
+    const trimmedDescription = description.trim()
+    const trimmedThreshold = voteThreshold.trim()
+    const parsedThreshold = trimmedThreshold ? Number(trimmedThreshold) : undefined
+
+    setNameError(null)
+    setThresholdError(null)
+    setSubmitError(null)
+
+    if (!trimmedName) {
+      setNameError('Name is required.')
+      return
+    }
+
+    if (parsedThreshold !== undefined && (!Number.isInteger(parsedThreshold) || parsedThreshold < 1)) {
+      setThresholdError('Vote threshold must be a positive number.')
+      return
+    }
+
+    const result = await executeCreate({
+      input: {
+        name: trimmedName,
+        description: trimmedDescription || null,
+        voteThreshold: parsedThreshold ?? null,
+      },
+    })
+
+    if (result.error) {
+      setSubmitError(result.error.message)
+      return
+    }
+
+    const playlistId = result.data?.createPlaylist.id
+    if (!playlistId) {
+      setSubmitError('Playlist could not be created.')
+      return
+    }
+
+    await refreshMyPlaylists(client)
+    router.back()
+    router.replace(`/playlists/${playlistId}`)
+  }
+
+  return (
+    <BottomSheet onClose={router.back}>
+      <View style={styles.header}>
+        <ThemedText type="subtitle" style={styles.title}>
+          New playlist
+        </ThemedText>
+        <ThemedText type="small" themeColor="textSecondary">
+          Start a shared room for voting on the next tracks.
+        </ThemedText>
+      </View>
+
+      <View style={styles.form}>
+        <Field label="Name" error={nameError}>
+          <GlassInput
+            placeholder="Name"
+            value={name}
+            onChangeText={(value) => {
+              setName(value)
+              if (nameError) setNameError(null)
+            }}
+            error={nameError}
+            autoFocus
+            returnKeyType="next"
+          />
+        </Field>
+
+        <Field label="Description">
+          <GlassInput placeholder="Description" value={description} onChangeText={setDescription} returnKeyType="next" />
+        </Field>
+
+        <Field label="Vote threshold" error={thresholdError}>
+          <GlassInput
+            placeholder="Vote threshold"
+            value={voteThreshold}
+            onChangeText={(value) => {
+              setVoteThreshold(value.replace(/\D/g, ''))
+              if (thresholdError) setThresholdError(null)
+            }}
+            error={thresholdError}
+            keyboardType="number-pad"
+          />
+        </Field>
+      </View>
+
+      {submitError ? (
+        <ThemedText selectable type="small" style={styles.errorText}>
+          {submitError}
+        </ThemedText>
+      ) : null}
+
+      <PrimaryButton disabled={fetching} onPress={submit}>
+        {fetching ? 'Creating...' : 'Create playlist'}
+      </PrimaryButton>
+    </BottomSheet>
+  )
+}
+
+function Field({ children, error, label }: { children: ReactNode; error?: string | null; label: string }) {
+  return (
+    <View style={styles.field}>
+      <ThemedText type="smallBold">{label}</ThemedText>
+      {children}
+      {error ? (
+        <ThemedText selectable type="small" style={styles.errorText}>
+          {error}
+        </ThemedText>
+      ) : null}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  header: {
+    gap: Spacing.two,
+  },
+  title: {
+    fontSize: 30,
+    lineHeight: 36,
+  },
+  form: {
+    gap: Spacing.three,
+  },
+  field: {
+    gap: Spacing.two,
+  },
+  errorText: {
+    color: Colors.skip,
+  },
+})

--- a/matchify-app/src/app/(tabs)/playlists/index.tsx
+++ b/matchify-app/src/app/(tabs)/playlists/index.tsx
@@ -1,29 +1,14 @@
 import { router } from 'expo-router'
 import { FlatList, Pressable, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { gql, useQuery } from 'urql'
+import { useQuery } from 'urql'
 
 import { GlassView } from '@/components/glass-view'
 import { PlaylistCard, type PlaylistCardPlaylist } from '@/components/playlist/playlist-card'
 import { ThemedText } from '@/components/themed-text'
 import { ThemedView } from '@/components/themed-view'
 import { Colors, Radius, ScreenPadding, Spacing } from '@/constants/theme'
-
-const MY_PLAYLISTS_QUERY = gql`
-  query MyPlaylists {
-    myPlaylists {
-      id
-      name
-      description
-      members {
-        id
-        displayName
-        profileImageUrl
-      }
-      voteThreshold
-    }
-  }
-`
+import { MY_PLAYLISTS_QUERY } from '@/lib/graphql/playlists'
 
 type MyPlaylistsData = {
   myPlaylists: PlaylistCardPlaylist[]
@@ -45,6 +30,14 @@ export default function PlaylistsScreen() {
     router.push(`/playlists/${id}`)
   }
 
+  const openCreate = () => {
+    router.push('/playlists/create')
+  }
+
+  const openJoin = () => {
+    router.push('/playlists/join')
+  }
+
   return (
     <ThemedView style={styles.container}>
       <SafeAreaView style={styles.safeArea}>
@@ -52,7 +45,7 @@ export default function PlaylistsScreen() {
           <ThemedText type="title" style={styles.title}>
             Playlists
           </ThemedText>
-          <Pressable accessibilityRole="button" style={({ pressed }) => [styles.joinButton, pressed && styles.pressed]}>
+          <Pressable accessibilityRole="button" onPress={openJoin} style={({ pressed }) => [styles.joinButton, pressed && styles.pressed]}>
             <GlassView glassEffectStyle="clear" colorScheme="dark" style={styles.joinPill}>
               <ThemedText type="smallBold">Join</ThemedText>
             </GlassView>
@@ -77,7 +70,7 @@ export default function PlaylistsScreen() {
           />
         )}
 
-        <Pressable accessibilityRole="button" style={({ pressed }) => [styles.fab, pressed && styles.pressed]}>
+        <Pressable accessibilityRole="button" onPress={openCreate} style={({ pressed }) => [styles.fab, pressed && styles.pressed]}>
           <ThemedText type="title" style={styles.fabIcon}>
             +
           </ThemedText>
@@ -133,7 +126,7 @@ function EmptyState() {
       <ThemedText type="small" themeColor="textSecondary" style={styles.centerCopy}>
         Join an invite to start voting with your group.
       </ThemedText>
-      <Pressable accessibilityRole="button" style={({ pressed }) => pressed && styles.pressed}>
+      <Pressable accessibilityRole="button" onPress={() => router.push('/playlists/join')} style={({ pressed }) => pressed && styles.pressed}>
         <GlassView glassEffectStyle="clear" colorScheme="dark" style={styles.ctaPill}>
           <ThemedText type="smallBold">Join with invite</ThemedText>
         </GlassView>

--- a/matchify-app/src/app/(tabs)/playlists/join.tsx
+++ b/matchify-app/src/app/(tabs)/playlists/join.tsx
@@ -1,0 +1,131 @@
+import { useState } from 'react'
+import { StyleSheet, View } from 'react-native'
+import { router } from 'expo-router'
+import { gql, useClient, useMutation } from 'urql'
+
+import { BottomSheet } from '@/components/ui/bottom-sheet'
+import { GlassInput } from '@/components/ui/glass-input'
+import { PrimaryButton } from '@/components/ui/primary-button'
+import { ThemedText } from '@/components/themed-text'
+import { Colors, Spacing } from '@/constants/theme'
+import { refreshMyPlaylists } from '@/lib/graphql/playlists'
+
+const JOIN_PLAYLIST_MUTATION = gql`
+  mutation JoinPlaylist($inviteCode: String!) {
+    joinPlaylist(inviteCode: $inviteCode) {
+      id
+    }
+  }
+`
+
+type JoinPlaylistData = {
+  joinPlaylist: {
+    id: string
+  }
+}
+
+type JoinPlaylistVariables = {
+  inviteCode: string
+}
+
+export default function JoinPlaylistScreen() {
+  const client = useClient()
+  const [{ fetching }, executeJoin] = useMutation<JoinPlaylistData, JoinPlaylistVariables>(JOIN_PLAYLIST_MUTATION)
+  const [inviteCode, setInviteCode] = useState('')
+  const [codeError, setCodeError] = useState<string | null>(null)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const submit = async () => {
+    const code = inviteCode.trim().toUpperCase()
+    setCodeError(null)
+    setSubmitError(null)
+
+    if (!/^[A-Z0-9]{6,8}$/.test(code)) {
+      setCodeError('Invite code must be 6-8 characters.')
+      return
+    }
+
+    const result = await executeJoin({ inviteCode: code })
+
+    if (result.error) {
+      setSubmitError(result.error.message)
+      return
+    }
+
+    const playlistId = result.data?.joinPlaylist.id
+    if (!playlistId) {
+      setSubmitError('Playlist could not be joined.')
+      return
+    }
+
+    await refreshMyPlaylists(client)
+    router.back()
+    router.replace(`/playlists/${playlistId}`)
+  }
+
+  return (
+    <BottomSheet onClose={router.back}>
+      <View style={styles.header}>
+        <ThemedText type="subtitle" style={styles.title}>
+          Join with invite
+        </ThemedText>
+        <ThemedText type="small" themeColor="textSecondary">
+          Enter the invite code shared by your group.
+        </ThemedText>
+      </View>
+
+      <View style={styles.form}>
+        <View style={styles.field}>
+          <ThemedText type="smallBold">Invite code</ThemedText>
+          <GlassInput
+            placeholder="Invite code"
+            value={inviteCode}
+            onChangeText={(value) => {
+              setInviteCode(value.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 8))
+              if (codeError) setCodeError(null)
+            }}
+            error={codeError}
+            autoCapitalize="characters"
+            autoCorrect={false}
+            autoFocus
+            maxLength={8}
+          />
+          {codeError ? (
+            <ThemedText selectable type="small" style={styles.errorText}>
+              {codeError}
+            </ThemedText>
+          ) : null}
+        </View>
+      </View>
+
+      {submitError ? (
+        <ThemedText selectable type="small" style={styles.errorText}>
+          {submitError}
+        </ThemedText>
+      ) : null}
+
+      <PrimaryButton disabled={fetching} onPress={submit}>
+        {fetching ? 'Joining...' : 'Join playlist'}
+      </PrimaryButton>
+    </BottomSheet>
+  )
+}
+
+const styles = StyleSheet.create({
+  header: {
+    gap: Spacing.two,
+  },
+  title: {
+    fontSize: 30,
+    lineHeight: 36,
+  },
+  form: {
+    gap: Spacing.three,
+  },
+  field: {
+    gap: Spacing.two,
+  },
+  errorText: {
+    color: Colors.skip,
+  },
+})

--- a/matchify-app/src/components/glass-surface.tsx
+++ b/matchify-app/src/components/glass-surface.tsx
@@ -23,6 +23,7 @@ const BLUR_TINT: Record<GlassColorScheme, "light" | "dark" | "default"> = {
 export type GlassSurfaceProps = ViewProps & {
   glassEffectStyle?: GlassStyle;
   colorScheme?: GlassColorScheme;
+  intensity?: number;
   tintColor?: string;
   forceFallback?: boolean;
 };
@@ -30,6 +31,7 @@ export type GlassSurfaceProps = ViewProps & {
 export function GlassSurface({
   glassEffectStyle = "regular",
   colorScheme = "dark",
+  intensity,
   tintColor,
   style,
   children,
@@ -56,7 +58,7 @@ export function GlassSurface({
 
   return (
     <BlurView
-      intensity={BLUR_INTENSITY[glassEffectStyle]}
+      intensity={intensity ?? BLUR_INTENSITY[glassEffectStyle]}
       tint={BLUR_TINT[colorScheme]}
       style={style}
       {...props}

--- a/matchify-app/src/components/ui/bottom-sheet.tsx
+++ b/matchify-app/src/components/ui/bottom-sheet.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useRef } from 'react'
+import {
+  Animated,
+  Easing,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  StyleSheet,
+  View,
+  type ViewProps,
+} from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+
+import { GlassView } from '@/components/ui/glass-view'
+import { Blur, Colors, Radius, ScreenPadding, Spacing } from '@/constants/theme'
+
+type BottomSheetProps = ViewProps & {
+  onClose: () => void
+}
+
+export function BottomSheet({ children, onClose, style }: BottomSheetProps) {
+  const insets = useSafeAreaInsets()
+  const progress = useRef(new Animated.Value(0)).current
+  const isClosing = useRef(false)
+
+  useEffect(() => {
+    Animated.timing(progress, {
+      toValue: 1,
+      duration: 300,
+      easing: Easing.inOut(Easing.ease),
+      useNativeDriver: true,
+    }).start()
+  }, [progress])
+
+  const close = () => {
+    if (isClosing.current) return
+    isClosing.current = true
+
+    Animated.timing(progress, {
+      toValue: 0,
+      duration: 300,
+      easing: Easing.inOut(Easing.ease),
+      useNativeDriver: true,
+    }).start(({ finished }) => {
+      if (finished) onClose()
+    })
+  }
+
+  return (
+    <View style={styles.root} pointerEvents="box-none">
+      <Animated.View style={[styles.backdrop, { opacity: progress }]}>
+        <Pressable accessibilityRole="button" accessibilityLabel="Close sheet" style={StyleSheet.absoluteFill} onPress={close} />
+      </Animated.View>
+      <KeyboardAvoidingView
+        pointerEvents="box-none"
+        behavior={Platform.select({ ios: 'padding', default: undefined })}
+        style={styles.keyboard}
+      >
+        <Animated.View
+          style={[
+            styles.sheetWrap,
+            {
+              paddingBottom: Math.max(insets.bottom, Spacing.three),
+              transform: [
+                {
+                  translateY: progress.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [480, 0],
+                  }),
+                },
+              ],
+            },
+          ]}
+        >
+          <GlassView
+            forceFallback
+            intensity={Blur.ultra}
+            glassEffectStyle="regular"
+            colorScheme="dark"
+            tintColor={Colors.glassRaised}
+            style={[styles.sheet, style]}
+          >
+            <View style={styles.handle} />
+            {children}
+          </GlassView>
+        </Animated.View>
+      </KeyboardAvoidingView>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  root: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'flex-end',
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(8,8,12,0.58)',
+  },
+  keyboard: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  sheetWrap: {
+    paddingHorizontal: ScreenPadding,
+  },
+  sheet: {
+    borderRadius: Radius.lg,
+    borderWidth: 1,
+    borderColor: Colors.glassBorder,
+    padding: Spacing.four,
+    overflow: 'hidden',
+    gap: Spacing.three,
+    backgroundColor: Colors.glassRaised,
+  },
+  handle: {
+    alignSelf: 'center',
+    width: 44,
+    height: 5,
+    borderRadius: Radius.full,
+    backgroundColor: Colors.glassHighlight,
+    marginBottom: Spacing.one,
+  },
+})

--- a/matchify-app/src/components/ui/glass-input.tsx
+++ b/matchify-app/src/components/ui/glass-input.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react'
+import { StyleSheet, TextInput, type TextInputProps, View } from 'react-native'
+
+import { GlassView } from '@/components/ui/glass-view'
+import { Colors, Radius, Spacing, Typography } from '@/constants/theme'
+
+export type GlassInputProps = TextInputProps & {
+  error?: string | null
+}
+
+export function GlassInput({ error, onBlur, onFocus, style, testID, ...props }: GlassInputProps) {
+  const [focused, setFocused] = useState(false)
+
+  return (
+    <View style={styles.wrap}>
+      <GlassView
+        testID={testID ? `${testID}-shell` : undefined}
+        forceFallback
+        glassEffectStyle="clear"
+        colorScheme="dark"
+        tintColor={Colors.glass}
+        style={[
+          styles.shell,
+          focused && styles.focused,
+          error && !focused && styles.error,
+        ]}
+      >
+        <TextInput
+          testID={testID}
+          placeholderTextColor={Colors.textTertiary}
+          selectionColor={Colors.accent}
+          style={[styles.input, style]}
+          onFocus={(event) => {
+            setFocused(true)
+            onFocus?.(event)
+          }}
+          onBlur={(event) => {
+            setFocused(false)
+            onBlur?.(event)
+          }}
+          {...props}
+        />
+      </GlassView>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    gap: Spacing.two,
+  },
+  shell: {
+    height: 48,
+    borderRadius: Radius.sm,
+    borderWidth: 1,
+    borderColor: Colors.glassBorder,
+    overflow: 'hidden',
+    justifyContent: 'center',
+    paddingHorizontal: Spacing.three,
+    backgroundColor: Colors.glass,
+  },
+  focused: {
+    borderColor: Colors.accent,
+    borderWidth: 1.5,
+  },
+  error: {
+    borderColor: Colors.skip,
+  },
+  input: {
+    ...Typography.default,
+    color: Colors.text,
+    padding: 0,
+  },
+})

--- a/matchify-app/src/components/ui/primary-button.tsx
+++ b/matchify-app/src/components/ui/primary-button.tsx
@@ -1,0 +1,54 @@
+import { useRef, type ReactNode } from 'react'
+import { Animated, Pressable, StyleSheet } from 'react-native'
+
+import { ThemedText } from '@/components/themed-text'
+import { Colors, Radius, Typography } from '@/constants/theme'
+
+type PrimaryButtonProps = {
+  children: ReactNode
+  disabled?: boolean
+  onPress: () => void
+}
+
+export function PrimaryButton({ children, disabled, onPress }: PrimaryButtonProps) {
+  const scale = useRef(new Animated.Value(1)).current
+
+  return (
+    <Animated.View style={{ transform: [{ scale }] }}>
+      <Pressable
+        accessibilityRole="button"
+        disabled={disabled}
+        onPress={onPress}
+        onPressIn={() => {
+          Animated.spring(scale, { toValue: 0.96, useNativeDriver: true, damping: 18, stiffness: 220 }).start()
+        }}
+        onPressOut={() => {
+          Animated.spring(scale, { toValue: 1, useNativeDriver: true, damping: 18, stiffness: 220 }).start()
+        }}
+        style={[styles.button, disabled && styles.disabled]}
+      >
+        <ThemedText type="smallBold" style={styles.text}>
+          {children}
+        </ThemedText>
+      </Pressable>
+    </Animated.View>
+  )
+}
+
+const styles = StyleSheet.create({
+  button: {
+    height: 48,
+    borderRadius: Radius.sm,
+    backgroundColor: Colors.brand,
+    alignItems: 'center',
+    justifyContent: 'center',
+    boxShadow: `0 10px 24px ${Colors.brandGlow}`,
+  },
+  text: {
+    ...Typography.smallBold,
+    color: Colors.text,
+  },
+  disabled: {
+    opacity: 0.62,
+  },
+})

--- a/matchify-app/src/lib/graphql/playlists.ts
+++ b/matchify-app/src/lib/graphql/playlists.ts
@@ -1,0 +1,20 @@
+import { gql, type Client } from 'urql'
+
+export const MY_PLAYLISTS_QUERY = gql`
+  query MyPlaylists {
+    myPlaylists {
+      id
+      name
+      description
+      members {
+        id
+        displayName
+        profileImageUrl
+      }
+      voteThreshold
+    }
+  }
+`
+
+export const refreshMyPlaylists = (client: Client) =>
+  client.query(MY_PLAYLISTS_QUERY, {}, { requestPolicy: 'network-only' }).toPromise()


### PR DESCRIPTION
## Summary
- Add animated bottom-sheet routes for creating and joining playlists
- Add reusable `GlassInput`, `BottomSheet`, and shared primary button UI
- Refresh `MyPlaylists` after mutations and navigate to the new playlist detail
- Wire playlist home actions to open the new sheet routes

## Testing
- Added unit tests for input focus styling, create validation, and join validation
- Added route tests covering mutation payloads, refresh behavior, and navigation
- Verified with targeted Jest suites and `tsc --noEmit`