### PR TITLE
Add vote action button

### DIFF
--- a/matchify-app/src/__tests__/components/action-button.test.tsx
+++ b/matchify-app/src/__tests__/components/action-button.test.tsx
@@ -1,0 +1,70 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+
+import { fireEvent, render } from '@testing-library/react-native'
+import { withSpring } from 'react-native-reanimated'
+
+import { ActionButton } from '@/components/vote/ActionButton'
+
+jest.mock('react-native-reanimated', () => {
+  const { View } = require('react-native')
+
+  return {
+    __esModule: true,
+    default: {
+      View,
+    },
+    interpolateColor: jest.fn((_value, _input, output) => output[0]),
+    useAnimatedStyle: jest.fn((callback) => callback()),
+    useSharedValue: jest.fn((value) => ({ value })),
+    withSpring: jest.fn((value) => value),
+  }
+})
+
+jest.mock('@/components/glass-surface', () => {
+  const { View } = require('react-native')
+
+  return {
+    GlassSurface: jest.fn(({ children, ...props }) => <View {...props}>{children}</View>),
+  }
+})
+
+describe('ActionButton', () => {
+  const mockWithSpring = jest.mocked(withSpring)
+
+  beforeEach(() => {
+    mockWithSpring.mockClear()
+  })
+
+  it('renders an accessible like button and calls onPress', () => {
+    const onPress = jest.fn()
+    const { getByLabelText } = render(<ActionButton type="like" onPress={onPress} />)
+
+    fireEvent.press(getByLabelText('Like'))
+
+    expect(onPress).toHaveBeenCalledTimes(1)
+  })
+
+  it('springs to pressed and released states', () => {
+    const { getByLabelText } = render(<ActionButton type="skip" onPress={jest.fn()} />)
+    const button = getByLabelText('Skip')
+
+    fireEvent(button, 'pressIn')
+    fireEvent(button, 'pressOut')
+
+    expect(mockWithSpring).toHaveBeenCalledWith(0.95, expect.any(Object))
+    expect(mockWithSpring).toHaveBeenCalledWith(1, expect.any(Object))
+  })
+
+  it('does not animate or press when disabled', () => {
+    const onPress = jest.fn()
+    const { getByLabelText } = render(<ActionButton type="like" onPress={onPress} disabled />)
+    const button = getByLabelText('Like')
+
+    fireEvent(button, 'pressIn')
+    fireEvent.press(button)
+
+    expect(onPress).not.toHaveBeenCalled()
+    expect(mockWithSpring).not.toHaveBeenCalled()
+    expect(button.props.style).toEqual(expect.objectContaining({ opacity: 0.4 }))
+  })
+})

--- a/matchify-app/src/components/vote/ActionButton.tsx
+++ b/matchify-app/src/components/vote/ActionButton.tsx
@@ -1,0 +1,129 @@
+import { Pressable, StyleSheet, View } from 'react-native'
+import Animated, {
+  interpolateColor,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+} from 'react-native-reanimated'
+import { SymbolView } from 'expo-symbols'
+
+import { GlassView } from '@/components/glass-view'
+import { Blur, Colors, Motion, Radius } from '@/constants/theme'
+
+type ActionButtonType = 'like' | 'skip'
+
+type ActionButtonProps = {
+  type: ActionButtonType
+  onPress: () => void
+  disabled?: boolean
+}
+
+const BUTTON_SIZE = 64
+const ICON_SIZE = 28
+
+const BUTTON_CONFIG = {
+  like: {
+    accessibilityLabel: 'Like',
+    borderColor: Colors.like,
+    glowColor: Colors.likeGlow,
+    iconName: 'heart.fill',
+  },
+  skip: {
+    accessibilityLabel: 'Skip',
+    borderColor: Colors.skip,
+    glowColor: Colors.skipGlow,
+    iconName: 'xmark',
+  },
+} as const
+
+export function ActionButton({ type, onPress, disabled = false }: ActionButtonProps) {
+  const scale = useSharedValue(1)
+  const active = useSharedValue(0)
+  const config = BUTTON_CONFIG[type]
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    backgroundColor: interpolateColor(active.value, [0, 1], [Colors.glass, Colors.glassActive]),
+    transform: [{ scale: scale.value }],
+  }))
+
+  const handlePressIn = () => {
+    if (disabled) {
+      return
+    }
+
+    scale.value = withSpring(0.95, Motion.spring)
+    active.value = withSpring(1, Motion.spring)
+  }
+
+  const handlePressOut = () => {
+    if (disabled) {
+      return
+    }
+
+    scale.value = withSpring(1, Motion.spring)
+    active.value = withSpring(0, Motion.spring)
+  }
+
+  return (
+    <Pressable
+      accessibilityLabel={config.accessibilityLabel}
+      accessibilityRole="button"
+      disabled={disabled}
+      onPress={onPress}
+      onPressIn={handlePressIn}
+      onPressOut={handlePressOut}
+      style={disabled && styles.disabled}
+    >
+      <Animated.View
+        style={[
+          styles.button,
+          {
+            borderColor: config.borderColor,
+            boxShadow: `0 0 22px ${config.glowColor}`,
+          },
+          animatedStyle,
+        ]}
+      >
+        <GlassView
+          glassEffectStyle="regular"
+          colorScheme="dark"
+          intensity={Blur.regular}
+          style={styles.glass}
+        >
+          <View style={styles.content}>
+            <SymbolView
+              name={config.iconName}
+              tintColor={config.borderColor}
+              size={ICON_SIZE}
+              resizeMode="scaleAspectFit"
+              weight="semibold"
+            />
+          </View>
+        </GlassView>
+      </Animated.View>
+    </Pressable>
+  )
+}
+
+const styles = StyleSheet.create({
+  button: {
+    width: BUTTON_SIZE,
+    height: BUTTON_SIZE,
+    overflow: 'hidden',
+    borderRadius: Radius.full,
+    borderWidth: 1.5,
+  },
+  glass: {
+    flex: 1,
+    overflow: 'hidden',
+    borderRadius: Radius.full,
+  },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  disabled: {
+    opacity: 0.4,
+  },
+})


### PR DESCRIPTION
## Summary
- Add a new `ActionButton` component for like/skip voting actions.
- Use token-driven liquid glass styling with 64px circular sizing, semantic rings, and subtle glow.
- Add Reanimated press-in/press-out spring scaling and animated active fill.
- Cover accessibility and disabled-state behavior with unit tests.

## Testing
- Added focused unit tests for accessibility, press animation targets, and disabled interaction.
- Full Jest suite passed locally.
- TypeScript check passed locally.
- Lint completed with existing warnings only in generated GraphQL types.