### PR TITLE
Add seed-track multiselect flow

### DIFF
--- a/matchify-app/src/__tests__/screens/playlist-detail-screen.test.tsx
+++ b/matchify-app/src/__tests__/screens/playlist-detail-screen.test.tsx
@@ -109,6 +109,14 @@ describe('PlaylistDetailScreen', () => {
     expect(mockPush).toHaveBeenCalledWith('/(tabs)/vote?playlistId=playlist-1&playlistName=Friday%20Room')
   })
 
+  it('navigates to search in seed mode with the playlist id', () => {
+    const { getByText } = render(<PlaylistDetailScreen />)
+
+    fireEvent.press(getByText('Seed tracks'))
+
+    expect(mockPush).toHaveBeenCalledWith('/(tabs)/search?playlistId=playlist-1')
+  })
+
   it('subscribes to approved track events for the current playlist', () => {
     render(<PlaylistDetailScreen />)
 

--- a/matchify-app/src/__tests__/screens/search-screen.test.tsx
+++ b/matchify-app/src/__tests__/screens/search-screen.test.tsx
@@ -1,11 +1,30 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 
 import { act, fireEvent, render } from '@testing-library/react-native'
+import { Alert } from 'react-native'
 
+const mockBack = jest.fn()
+const mockDispatch = jest.fn()
+const mockUseLocalSearchParams = jest.fn()
+const mockUseNavigation = jest.fn()
+const mockUseMutation = jest.fn()
 const mockUseQuery = jest.fn()
+const mockClientQuery = jest.fn()
+
+jest.mock('expo-router', () => ({
+  router: {
+    back: () => mockBack(),
+  },
+  useLocalSearchParams: () => mockUseLocalSearchParams(),
+  useNavigation: () => mockUseNavigation(),
+}))
 
 jest.mock('urql', () => ({
   gql: jest.fn((strings: TemplateStringsArray) => strings.join('')),
+  useClient: () => ({
+    query: (...args: unknown[]) => mockClientQuery(...args),
+  }),
+  useMutation: (mutation: unknown) => mockUseMutation(mutation),
   useQuery: (options: unknown) => mockUseQuery(options),
 }))
 
@@ -32,6 +51,10 @@ const resultTrack = {
 beforeEach(() => {
   jest.useFakeTimers()
   jest.clearAllMocks()
+  mockUseLocalSearchParams.mockReturnValue({})
+  mockUseNavigation.mockReturnValue({ addListener: jest.fn(() => jest.fn()), dispatch: mockDispatch })
+  mockUseMutation.mockReturnValue([{ fetching: false }, jest.fn().mockResolvedValue({ data: {} })])
+  mockClientQuery.mockReturnValue({ toPromise: jest.fn().mockResolvedValue({}) })
   mockUseQuery.mockReturnValue([{ fetching: false, data: undefined, error: undefined }])
 })
 
@@ -99,6 +122,162 @@ describe('SearchScreen', () => {
     fireEvent.press(getByTestId('track-search-row-spotify-1'))
 
     expect(getByTestId('track-search-selected-spotify-1')).toBeTruthy()
+  })
+
+  it('shows ordered row badges and the add button in playlist seed mode', () => {
+    mockUseLocalSearchParams.mockReturnValue({ playlistId: 'playlist-1' })
+    mockUseQuery.mockReturnValue([
+      {
+        fetching: false,
+        data: {
+          searchTracks: [
+            resultTrack,
+            { ...resultTrack, spotifyTrackId: 'spotify-2', title: 'Wait' },
+          ],
+        },
+        error: undefined,
+      },
+    ])
+
+    const { getByText, getByTestId } = render(<SearchScreen />)
+
+    fireEvent.press(getByTestId('track-search-row-spotify-2'))
+    fireEvent.press(getByTestId('track-search-row-spotify-1'))
+
+    expect(getByText('Add 2 tracks')).toBeTruthy()
+    expect(getByTestId('track-search-selected-spotify-2')).toHaveTextContent('1')
+    expect(getByTestId('track-search-selected-spotify-1')).toHaveTextContent('2')
+  })
+
+  it('adds selected tracks in one mutation, refreshes the playlist, and navigates back', async () => {
+    const executeMutation = jest.fn().mockResolvedValue({ data: { addInitialTracks: [] } })
+    mockUseLocalSearchParams.mockReturnValue({ playlistId: 'playlist-1' })
+    mockUseMutation.mockReturnValue([{ fetching: false }, executeMutation])
+    mockUseQuery.mockReturnValue([
+      {
+        fetching: false,
+        data: {
+          searchTracks: [
+            resultTrack,
+            { ...resultTrack, spotifyTrackId: 'spotify-2', title: 'Wait' },
+          ],
+        },
+        error: undefined,
+      },
+    ])
+
+    const { getByText, getByTestId } = render(<SearchScreen />)
+
+    fireEvent.press(getByTestId('track-search-row-spotify-1'))
+    fireEvent.press(getByTestId('track-search-row-spotify-2'))
+    await act(async () => {
+      fireEvent.press(getByText('Add 2 tracks'))
+    })
+
+    expect(executeMutation).toHaveBeenCalledWith({
+      playlistId: 'playlist-1',
+      spotifyTrackIds: ['spotify-1', 'spotify-2'],
+    })
+    expect(mockClientQuery).toHaveBeenCalledWith(expect.anything(), { id: 'playlist-1' }, { requestPolicy: 'network-only' })
+    expect(mockBack).toHaveBeenCalledTimes(1)
+  })
+
+  it('caps selection at 50 tracks', () => {
+    mockUseLocalSearchParams.mockReturnValue({ playlistId: 'playlist-1' })
+    const tracksForBatch = (batch: number) =>
+      Array.from({ length: 10 }, (_, index) => {
+        const trackNumber = batch * 10 + index + 1
+
+        return {
+          ...resultTrack,
+          spotifyTrackId: `spotify-${trackNumber}`,
+          title: `Track ${trackNumber}`,
+        }
+      })
+
+    mockUseQuery.mockReturnValue([
+      {
+        fetching: false,
+        data: {
+          searchTracks: tracksForBatch(0),
+        },
+        error: undefined,
+      },
+    ])
+
+    const { getByText, getByTestId, queryByTestId, rerender } = render(<SearchScreen />)
+
+    for (let batch = 0; batch < 5; batch += 1) {
+      mockUseQuery.mockReturnValue([
+        {
+          fetching: false,
+          data: {
+            searchTracks: tracksForBatch(batch),
+          },
+          error: undefined,
+        },
+      ])
+      rerender(<SearchScreen />)
+
+      for (let index = 1; index <= 10; index += 1) {
+        fireEvent.press(getByTestId(`track-search-row-spotify-${batch * 10 + index}`))
+      }
+    }
+
+    mockUseQuery.mockReturnValue([
+      {
+        fetching: false,
+        data: {
+          searchTracks: [
+            {
+              ...resultTrack,
+              spotifyTrackId: 'spotify-51',
+              title: 'Track 51',
+            },
+          ],
+        },
+        error: undefined,
+      },
+    ])
+    rerender(<SearchScreen />)
+    fireEvent.press(getByTestId('track-search-row-spotify-51'))
+
+    expect(getByText('50 selected')).toBeTruthy()
+    expect(getByText('Add 50 tracks')).toBeTruthy()
+    expect(queryByTestId('track-search-selected-spotify-51')).toBeNull()
+  })
+
+  it('confirms back navigation and clears selected tracks before discarding', () => {
+    const unsubscribe = jest.fn()
+    const preventDefault = jest.fn()
+    const action = { type: 'GO_BACK' }
+    let beforeRemove: ((event: { preventDefault: () => void; data: { action: unknown } }) => void) | undefined
+
+    const addListener = jest.fn((eventName: string, handler: typeof beforeRemove) => {
+      if (eventName === 'beforeRemove') {
+        beforeRemove = handler
+      }
+
+      return unsubscribe
+    })
+    mockUseLocalSearchParams.mockReturnValue({ playlistId: 'playlist-1' })
+    mockUseNavigation.mockReturnValue({ addListener, dispatch: mockDispatch })
+    mockUseQuery.mockReturnValue([{ fetching: false, data: { searchTracks: [resultTrack] }, error: undefined }])
+    jest.spyOn(Alert, 'alert').mockImplementation((title, message, buttons) => {
+      buttons?.[1]?.onPress?.()
+    })
+
+    const { getByTestId, queryByTestId } = render(<SearchScreen />)
+
+    fireEvent.press(getByTestId('track-search-row-spotify-1'))
+    act(() => {
+      beforeRemove?.({ preventDefault, data: { action } })
+    })
+
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(Alert.alert).toHaveBeenCalledWith('Discard selected tracks?', expect.any(String), expect.any(Array))
+    expect(mockDispatch).toHaveBeenCalledWith(action)
+    expect(queryByTestId('track-search-selected-spotify-1')).toBeNull()
   })
 
   it('shows a no-results state for completed empty searches', () => {

--- a/matchify-app/src/app/(tabs)/playlists/[id].tsx
+++ b/matchify-app/src/app/(tabs)/playlists/[id].tsx
@@ -123,6 +123,10 @@ export default function PlaylistDetailScreen() {
     );
   };
 
+  const seedTracks = () => {
+    router.push(`/(tabs)/search?playlistId=${id}`);
+  };
+
   const refresh = () => {
     void executeQuery({ requestPolicy: "network-only" });
   };
@@ -163,8 +167,8 @@ export default function PlaylistDetailScreen() {
 
         <Pressable
           accessibilityRole="button"
-          disabled
-          style={styles.proposeFab}
+          onPress={seedTracks}
+          style={({ pressed }) => [styles.proposeFab, pressed && styles.pressed]}
         >
           <GlassView
             glassEffectStyle="clear"
@@ -172,7 +176,7 @@ export default function PlaylistDetailScreen() {
             style={styles.proposePill}
           >
             <ThemedText type="smallBold" themeColor="brand">
-              Propose a Track
+              Seed tracks
             </ThemedText>
           </GlassView>
         </Pressable>
@@ -397,7 +401,6 @@ const styles = StyleSheet.create({
     left: "50%",
     transform: [{ translateX: "-50%" }],
     borderRadius: Radius.full,
-    opacity: 0.58,
   },
   proposePill: {
     minHeight: 52,

--- a/matchify-app/src/app/(tabs)/search.tsx
+++ b/matchify-app/src/app/(tabs)/search.tsx
@@ -1,25 +1,38 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { FlatList, StyleSheet, View } from 'react-native'
+import { router, useLocalSearchParams, useNavigation } from 'expo-router'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Alert, Animated, FlatList, Pressable, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { useQuery } from 'urql'
+import { useClient, useMutation, useQuery } from 'urql'
 
+import { GlassView } from '@/components/glass-view'
 import { GlassInput } from '@/components/ui/glass-input'
 import { ThemedText } from '@/components/themed-text'
 import { ThemedView } from '@/components/themed-view'
 import { TrackSearchRow, type TrackSearchRowTrack } from '@/components/track/track-search-row'
 import { Colors, Radius, ScreenPadding, Spacing } from '@/constants/theme'
+import { ADD_INITIAL_TRACKS_MUTATION, PLAYLIST_DETAIL_QUERY } from '@/lib/graphql/playlists'
 import { SEARCH_TRACKS_QUERY } from '@/lib/graphql/search'
 
 const SEARCH_LIMIT = 20
+const MAX_SELECTED_TRACKS = 50
 
 type SearchTracksData = {
   searchTracks: TrackSearchRowTrack[]
 }
 
+type AddInitialTracksData = {
+  addInitialTracks: unknown[]
+}
+
 export default function SearchScreen() {
+  const { playlistId } = useLocalSearchParams<{ playlistId?: string }>()
+  const navigation = useNavigation()
+  const client = useClient()
   const [query, setQuery] = useState('')
   const [debouncedQuery, setDebouncedQuery] = useState('')
   const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set())
+  const actionBarProgress = useRef(new Animated.Value(0)).current
+  const completingAddRef = useRef(false)
 
   const trimmedQuery = query.trim()
 
@@ -42,6 +55,7 @@ export default function SearchScreen() {
     variables: { query: debouncedQuery, limit: SEARCH_LIMIT },
     pause: debouncedQuery.length === 0,
   })
+  const [{ fetching: addingTracks }, addInitialTracks] = useMutation<AddInitialTracksData>(ADD_INITIAL_TRACKS_MUTATION)
 
   const tracks = data?.searchTracks ?? []
   const showInitialPrompt = trimmedQuery.length === 0
@@ -49,6 +63,17 @@ export default function SearchScreen() {
   const showNoResults = debouncedQuery.length > 0 && !fetching && !error && tracks.length === 0
 
   const selectedCount = selectedIds.size
+  const selectedTrackIds = useMemo(() => Array.from(selectedIds), [selectedIds])
+  const selectionOrder = useMemo(() => {
+    const order = new Map<string, number>()
+
+    selectedTrackIds.forEach((id, index) => {
+      order.set(id, index + 1)
+    })
+
+    return order
+  }, [selectedTrackIds])
+  const addButtonLabel = `Add ${selectedCount} ${selectedCount === 1 ? 'track' : 'tracks'}`
 
   const toggleTrack = useCallback((track: TrackSearchRowTrack) => {
     setSelectedIds((current) => {
@@ -57,12 +82,64 @@ export default function SearchScreen() {
       if (next.has(track.spotifyTrackId)) {
         next.delete(track.spotifyTrackId)
       } else {
+        if (next.size >= MAX_SELECTED_TRACKS) {
+          return current
+        }
+
         next.add(track.spotifyTrackId)
       }
 
       return next
     })
   }, [])
+
+  const confirmAddTracks = useCallback(async () => {
+    if (!playlistId || selectedTrackIds.length === 0 || addingTracks) return
+
+    const result = await addInitialTracks({
+      playlistId,
+      spotifyTrackIds: selectedTrackIds,
+    })
+
+    if (result.error) {
+      Alert.alert('Tracks could not be added', 'Check your connection and try again.')
+      return
+    }
+
+    await client.query(PLAYLIST_DETAIL_QUERY, { id: playlistId }, { requestPolicy: 'network-only' }).toPromise()
+    completingAddRef.current = true
+    setSelectedIds(new Set())
+    router.back()
+  }, [addInitialTracks, addingTracks, client, playlistId, selectedTrackIds])
+
+  useEffect(() => {
+    Animated.spring(actionBarProgress, {
+      toValue: playlistId && selectedCount > 0 ? 1 : 0,
+      useNativeDriver: true,
+      damping: 18,
+      stiffness: 220,
+    }).start()
+  }, [actionBarProgress, playlistId, selectedCount])
+
+  useEffect(() => {
+    return navigation.addListener('beforeRemove', (event) => {
+      if (selectedIds.size === 0 || completingAddRef.current) return
+
+      event.preventDefault()
+
+      Alert.alert('Discard selected tracks?', 'Your selected tracks will not be added to this playlist.', [
+        { text: 'Keep editing', style: 'cancel' },
+        {
+          text: 'Discard',
+          style: 'destructive',
+          onPress: () => {
+            setSelectedIds(new Set())
+            navigation.dispatch(event.data.action)
+          },
+        },
+      ])
+    })
+  }, [navigation, selectedIds])
 
   const listContentStyle = useMemo(
     () => [styles.listContent, (showInitialPrompt || showNoResults || error) && styles.stateListContent],
@@ -103,7 +180,12 @@ export default function SearchScreen() {
             keyExtractor={(item) => item.spotifyTrackId}
             keyboardShouldPersistTaps="handled"
             renderItem={({ item }) => (
-              <TrackSearchRow track={item} selected={selectedIds.has(item.spotifyTrackId)} onToggle={toggleTrack} />
+              <TrackSearchRow
+                track={item}
+                selected={selectedIds.has(item.spotifyTrackId)}
+                selectionIndex={selectionOrder.get(item.spotifyTrackId)}
+                onToggle={toggleTrack}
+              />
             )}
             contentContainerStyle={listContentStyle}
             ItemSeparatorComponent={() => <View style={styles.separator} />}
@@ -112,6 +194,39 @@ export default function SearchScreen() {
             }
           />
         )}
+
+        {playlistId && selectedCount > 0 ? (
+          <Animated.View
+            pointerEvents={selectedCount > 0 ? 'auto' : 'none'}
+            style={[
+              styles.addBar,
+              {
+                opacity: actionBarProgress,
+                transform: [
+                  {
+                    translateY: actionBarProgress.interpolate({
+                      inputRange: [0, 1],
+                      outputRange: [28, 0],
+                    }),
+                  },
+                ],
+              },
+            ]}
+          >
+            <Pressable
+              accessibilityRole="button"
+              disabled={addingTracks || selectedCount === 0}
+              onPress={confirmAddTracks}
+              style={({ pressed }) => [styles.addButton, pressed && styles.pressed, addingTracks && styles.addButtonDisabled]}
+            >
+              <GlassView glassEffectStyle="clear" colorScheme="dark" style={styles.addPill}>
+                <ThemedText type="smallBold" style={styles.addLabel}>
+                  {addingTracks ? 'Adding...' : addButtonLabel}
+                </ThemedText>
+              </GlassView>
+            </Pressable>
+          </Animated.View>
+        ) : null}
       </SafeAreaView>
     </ThemedView>
   )
@@ -199,6 +314,38 @@ const styles = StyleSheet.create({
   },
   separator: {
     height: Spacing.two,
+  },
+  addBar: {
+    position: 'absolute',
+    left: ScreenPadding,
+    right: ScreenPadding,
+    bottom: 96,
+    alignItems: 'center',
+  },
+  addButton: {
+    borderRadius: Radius.full,
+  },
+  addButtonDisabled: {
+    opacity: 0.72,
+  },
+  addPill: {
+    minHeight: 54,
+    borderRadius: Radius.full,
+    borderWidth: 1,
+    borderColor: Colors.glassHighlight,
+    paddingHorizontal: Spacing.four,
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+    backgroundColor: Colors.brandGlow,
+    boxShadow: `0 16px 36px ${Colors.brandGlow}`,
+  },
+  addLabel: {
+    color: Colors.text,
+  },
+  pressed: {
+    opacity: 0.78,
+    transform: [{ scale: 0.99 }],
   },
   skeletonList: {
     paddingHorizontal: ScreenPadding,

--- a/matchify-app/src/components/track/track-search-row.tsx
+++ b/matchify-app/src/components/track/track-search-row.tsx
@@ -17,10 +17,11 @@ export type TrackSearchRowTrack = {
 type TrackSearchRowProps = {
   track: TrackSearchRowTrack
   selected: boolean
+  selectionIndex?: number
   onToggle: (track: TrackSearchRowTrack) => void
 }
 
-export function TrackSearchRow({ track, selected, onToggle }: TrackSearchRowProps) {
+export function TrackSearchRow({ track, selected, selectionIndex, onToggle }: TrackSearchRowProps) {
   return (
     <Pressable
       accessibilityRole="button"
@@ -59,7 +60,7 @@ export function TrackSearchRow({ track, selected, onToggle }: TrackSearchRowProp
       <View style={[styles.checkSlot, selected && styles.checkSlotSelected]}>
         {selected ? (
           <ThemedText testID={`track-search-selected-${track.spotifyTrackId}`} type="micro" style={styles.checkmark}>
-            ✓
+            {selectionIndex ?? '✓'}
           </ThemedText>
         ) : null}
       </View>

--- a/matchify-app/src/lib/graphql/playlists.ts
+++ b/matchify-app/src/lib/graphql/playlists.ts
@@ -55,5 +55,20 @@ export const TRACK_APPROVED_SUBSCRIPTION = gql`
   }
 `
 
+export const ADD_INITIAL_TRACKS_MUTATION = gql`
+  mutation AddInitialTracks($playlistId: String!, $spotifyTrackIds: [String!]!) {
+    addInitialTracks(playlistId: $playlistId, spotifyTrackIds: $spotifyTrackIds) {
+      id
+      spotifyTrackId
+      title
+      artist
+      albumArtUrl
+      durationMs
+      likeCount
+      createdAt
+    }
+  }
+`
+
 export const refreshMyPlaylists = (client: Client) =>
   client.query(MY_PLAYLISTS_QUERY, {}, { requestPolicy: 'network-only' }).toPromise()


### PR DESCRIPTION
## Summary
- Add playlist-seeded track search from the playlist detail screen.
- Support multi-select with ordered badges, a 50-track cap, and a floating add bar.
- Submit all selected Spotify IDs in one `addInitialTracks` mutation, refresh playlist detail, and return to the playlist screen.
- Confirm before discarding selected tracks on back navigation.

## Testing
- Added and updated unit tests for playlist navigation, search selection, mutation submission, selection limits, and discard confirmation.
- Full Jest suite passed locally.