### PR TITLE
Add playlist swipe recommendations

### DIFF
--- a/matchify-app/src/app/(tabs)/playlists/[id]/vote.tsx
+++ b/matchify-app/src/app/(tabs)/playlists/[id]/vote.tsx
@@ -1,7 +1,7 @@
 import { useLocalSearchParams } from 'expo-router'
 import { SymbolView } from 'expo-symbols'
 import type { ReactNode } from 'react'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Pressable, StyleSheet, View, useWindowDimensions } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Animated, {
@@ -9,7 +9,7 @@ import Animated, {
   useSharedValue,
   withSpring,
 } from 'react-native-reanimated'
-import { useMutation, useQuery, useSubscription } from 'urql'
+import { useClient, useMutation, useQuery, useSubscription } from 'urql'
 
 import { GlassView } from '@/components/glass-view'
 import { ThemedText } from '@/components/themed-text'
@@ -19,12 +19,15 @@ import { VoteCard, type VoteCardTrack } from '@/components/vote/VoteCard'
 import { Blur, Colors, Motion, Radius, ScreenPadding, Spacing } from '@/constants/theme'
 import {
   NEW_PROPOSAL_SUBSCRIPTION,
+  NEXT_RECOMMENDATION_QUERY,
   NEXT_PROPOSAL_QUERY,
+  RESPOND_TO_RECOMMENDATION_MUTATION,
   VOTE_ON_TRACK_MUTATION,
 } from '@/lib/graphql/vote'
 import { useSubscriptionConnectionStatus } from '@/lib/subscription-status'
 
 type VoteType = 'LIKE' | 'SKIP'
+type RecommendationAction = 'ACCEPT' | 'REJECT'
 
 type NextProposalData = {
   nextProposal: VoteCardTrack | null
@@ -36,6 +39,33 @@ type VoteOnTrackData = {
     status: string
     likeCount: number
   }
+}
+
+type RecommendationTrack = {
+  spotifyTrackId: string
+  title: string
+  artist: string
+  album?: string | null
+  albumArtUrl?: string | null
+  previewUrl?: string | null
+  durationMs: number
+}
+
+type NextRecommendationData = {
+  nextRecommendation: RecommendationTrack | null
+}
+
+type NextRecommendationVariables = {
+  playlistId?: string
+  excludedSpotifyTrackIds?: string[]
+}
+
+type RespondToRecommendationData = {
+  respondToRecommendation: {
+    id: string
+    status: string
+    likeCount: number
+  } | null
 }
 
 type NewProposalData = {
@@ -50,6 +80,15 @@ const firstParam = (value: string | string[] | undefined) => {
   return value
 }
 
+const toVoteCardTrack = (recommendation: RecommendationTrack): VoteCardTrack => ({
+  id: recommendation.spotifyTrackId,
+  title: recommendation.title,
+  artist: recommendation.artist,
+  album: recommendation.album,
+  albumArtUrl: recommendation.albumArtUrl,
+  durationMs: recommendation.durationMs,
+})
+
 export default function VoteScreen() {
   const { id: playlistIdParam, playlistName: playlistNameParam } = useLocalSearchParams<{
     id?: string | string[]
@@ -58,10 +97,14 @@ export default function VoteScreen() {
   const playlistId = firstParam(playlistIdParam)
   const playlistName = firstParam(playlistNameParam) ?? 'Vote'
   const { width } = useWindowDimensions()
+  const client = useClient()
   const [votingTrackId, setVotingTrackId] = useState<string | null>(null)
   const [toastMessage, setToastMessage] = useState<string | null>(null)
   const [hasNewProposalBadge, setHasNewProposalBadge] = useState(false)
+  const [recommendationQueue, setRecommendationQueue] = useState<VoteCardTrack[]>([])
   const voteInFlightRef = useRef(false)
+  const recommendationPrefetchRef = useRef(false)
+  const consumedRecommendationIdsRef = useRef<Set<string>>(new Set())
   const toastTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const subscriptionStatus = useSubscriptionConnectionStatus()
   const cardTranslateX = useSharedValue(width + EXIT_OVERSHOOT)
@@ -74,6 +117,19 @@ export default function VoteScreen() {
   })
   const [, voteOnTrack] = useMutation<VoteOnTrackData, { trackId: string; vote: VoteType }>(VOTE_ON_TRACK_MUTATION)
   const track = data?.nextProposal ?? null
+  const [{ data: recommendationData, fetching: fetchingRecommendation, error: recommendationError }, executeRecommendationQuery] =
+    useQuery<NextRecommendationData>({
+      query: NEXT_RECOMMENDATION_QUERY,
+      variables: { playlistId, excludedSpotifyTrackIds: [] },
+      pause: !playlistId || fetching || Boolean(track),
+    })
+  const [, respondToRecommendation] = useMutation<
+    RespondToRecommendationData,
+    { playlistId: string; spotifyTrackId: string; action: RecommendationAction }
+  >(RESPOND_TO_RECOMMENDATION_MUTATION)
+  const recommendationTrack = recommendationQueue[0] ?? null
+  const activeTrack = track ?? recommendationTrack
+  const isDiscoveryMode = !track && Boolean(recommendationTrack)
 
   useSubscription<NewProposalData, NewProposalData | undefined, { playlistId?: string }>(
     {
@@ -94,10 +150,81 @@ export default function VoteScreen() {
     },
   )
 
-  const trackId = track?.id
-  const isInitialLoading = fetching && !data
+  const trackId = activeTrack?.id
+  const isInitialLoading = (fetching && !data) || (!track && fetchingRecommendation && !recommendationData)
   const isVoting = Boolean(votingTrackId)
   const exitDistance = width + EXIT_OVERSHOOT
+  const activeError = error ?? (!track ? recommendationError : undefined)
+
+  useEffect(() => {
+    setRecommendationQueue([])
+    consumedRecommendationIdsRef.current = new Set()
+  }, [playlistId])
+
+  useEffect(() => {
+    const recommendation = recommendationData?.nextRecommendation
+
+    if (!recommendation) return
+
+    const nextTrack = toVoteCardTrack(recommendation)
+    setRecommendationQueue((currentQueue) => {
+      if (
+        consumedRecommendationIdsRef.current.has(nextTrack.id) ||
+        currentQueue.some((queuedTrack) => queuedTrack.id === nextTrack.id)
+      ) {
+        return currentQueue
+      }
+
+      return [...currentQueue, nextTrack]
+    })
+  }, [recommendationData?.nextRecommendation])
+
+  const recommendationExclusions = useCallback(
+    (queuedTracks: VoteCardTrack[] = recommendationQueue) =>
+      Array.from(new Set([...Array.from(consumedRecommendationIdsRef.current), ...queuedTracks.map((queuedTrack) => queuedTrack.id)])),
+    [recommendationQueue],
+  )
+
+  const prefetchRecommendation = useCallback(
+    async (excludeIds: string[]) => {
+      if (!playlistId || recommendationPrefetchRef.current) return
+
+      recommendationPrefetchRef.current = true
+      const result = await client
+        .query<NextRecommendationData, NextRecommendationVariables>(
+          NEXT_RECOMMENDATION_QUERY,
+          { playlistId, excludedSpotifyTrackIds: excludeIds },
+          { requestPolicy: 'network-only' },
+        )
+        .toPromise()
+        .finally(() => {
+          recommendationPrefetchRef.current = false
+        })
+
+      const recommendation = result.data?.nextRecommendation
+
+      if (!recommendation || result.error) return
+
+      const nextTrack = toVoteCardTrack(recommendation)
+      setRecommendationQueue((currentQueue) => {
+        if (
+          consumedRecommendationIdsRef.current.has(nextTrack.id) ||
+          currentQueue.some((queuedTrack) => queuedTrack.id === nextTrack.id)
+        ) {
+          return currentQueue
+        }
+
+        return [...currentQueue, nextTrack]
+      })
+    },
+    [client, playlistId],
+  )
+
+  useEffect(() => {
+    if (track || fetchingRecommendation || recommendationQueue.length !== 1) return
+
+    void prefetchRecommendation(recommendationExclusions())
+  }, [fetchingRecommendation, prefetchRecommendation, recommendationExclusions, recommendationQueue, track])
 
   useEffect(() => {
     if (!trackId) return
@@ -148,6 +275,21 @@ export default function VoteScreen() {
     void executeQuery({ requestPolicy: 'network-only' })
   }
 
+  const refreshNextRecommendation = () => {
+    setRecommendationQueue([])
+    consumedRecommendationIdsRef.current = new Set()
+    void executeRecommendationQuery({ requestPolicy: 'network-only' })
+  }
+
+  const retryActiveQueue = () => {
+    if (track || error) {
+      refreshNextProposal()
+      return
+    }
+
+    refreshNextRecommendation()
+  }
+
   const castVote = async (vote: VoteType) => {
     if (!track || voteInFlightRef.current) return
 
@@ -176,6 +318,58 @@ export default function VoteScreen() {
     setVotingTrackId(null)
     setHasNewProposalBadge(false)
     refreshNextProposal()
+  }
+
+  const respondToDiscovery = async (action: RecommendationAction) => {
+    if (!playlistId || !recommendationTrack || voteInFlightRef.current) return
+
+    const swipedTrack = recommendationTrack
+    consumedRecommendationIdsRef.current.add(swipedTrack.id)
+    voteInFlightRef.current = true
+    setVotingTrackId(swipedTrack.id)
+    const queuedAfterSwipe = recommendationQueue.filter((queuedTrack) => queuedTrack.id !== swipedTrack.id)
+    setRecommendationQueue(queuedAfterSwipe)
+
+    const direction = action === 'ACCEPT' ? 1 : -1
+    cardTranslateX.value = withSpring(direction * exitDistance, Motion.spring)
+    cardOpacity.value = withSpring(0, Motion.spring)
+
+    const result = await respondToRecommendation({
+      playlistId,
+      spotifyTrackId: swipedTrack.id,
+      action,
+    }).catch((caughtError: unknown) => {
+      const message = caughtError instanceof Error ? caughtError.message : 'Please try again.'
+
+      consumedRecommendationIdsRef.current.delete(swipedTrack.id)
+      setRecommendationQueue((currentQueue) => [
+        swipedTrack,
+        ...currentQueue.filter((queuedTrack) => queuedTrack.id !== swipedTrack.id),
+      ])
+      recoverFromVoteError(message)
+      return null
+    })
+
+    if (!result) return
+
+    if (result.error) {
+      consumedRecommendationIdsRef.current.delete(swipedTrack.id)
+      setRecommendationQueue((currentQueue) => [
+        swipedTrack,
+        ...currentQueue.filter((queuedTrack) => queuedTrack.id !== swipedTrack.id),
+      ])
+      recoverFromVoteError(result.error.message)
+      return
+    }
+
+    voteInFlightRef.current = false
+    setVotingTrackId(null)
+
+    if (action === 'ACCEPT') {
+      refreshNextProposal()
+    }
+
+    void prefetchRecommendation(recommendationExclusions(queuedAfterSwipe))
   }
 
   return (
@@ -208,22 +402,38 @@ export default function VoteScreen() {
 
           {isInitialLoading ? (
             <VoteCardSkeleton />
-          ) : error ? (
-            <ErrorState onRetry={refreshNextProposal} />
-          ) : track ? (
+          ) : activeError ? (
+            <ErrorState onRetry={retryActiveQueue} />
+          ) : activeTrack ? (
             <>
               <Animated.View style={[styles.cardWrap, cardAnimatedStyle]}>
                 <VoteCard
-                  key={track.id}
-                  track={track}
-                  onSwipeLeft={() => void castVote('SKIP')}
-                  onSwipeRight={() => void castVote('LIKE')}
+                  key={`${isDiscoveryMode ? 'discover' : 'vote'}-${activeTrack.id}`}
+                  track={activeTrack}
+                  onSwipeLeft={() => void (isDiscoveryMode ? respondToDiscovery('REJECT') : castVote('SKIP'))}
+                  onSwipeRight={() => void (isDiscoveryMode ? respondToDiscovery('ACCEPT') : castVote('LIKE'))}
                 />
               </Animated.View>
 
+              {isDiscoveryMode && (
+                <GlassView glassEffectStyle="regular" colorScheme="dark" style={styles.discoveryBadge}>
+                  <ThemedText type="micro" themeColor="textSecondary">
+                    Discovery pick
+                  </ThemedText>
+                </GlassView>
+              )}
+
               <View style={styles.actions}>
-                <ActionButton type="skip" disabled={isVoting} onPress={() => void castVote('SKIP')} />
-                <ActionButton type="like" disabled={isVoting} onPress={() => void castVote('LIKE')} />
+                <ActionButton
+                  type="skip"
+                  disabled={isVoting}
+                  onPress={() => void (isDiscoveryMode ? respondToDiscovery('REJECT') : castVote('SKIP'))}
+                />
+                <ActionButton
+                  type="like"
+                  disabled={isVoting}
+                  onPress={() => void (isDiscoveryMode ? respondToDiscovery('ACCEPT') : castVote('LIKE'))}
+                />
               </View>
             </>
           ) : (
@@ -275,10 +485,10 @@ function EmptyState() {
         <SymbolView name="music.note" tintColor={Colors.like} size={38} resizeMode="scaleAspectFit" weight="semibold" />
       </GlassView>
       <ThemedText type="subtitle" style={styles.centerText}>
-        {"You're all caught up!"}
+        {"You're all caught up"}
       </ThemedText>
       <ThemedText type="small" themeColor="textSecondary" style={styles.centerText}>
-        Come back when someone proposes a new track
+        No proposals or discoveries are available right now
       </ThemedText>
     </View>
   )
@@ -351,6 +561,17 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: Spacing.four,
     alignSelf: 'center',
+    minHeight: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+    borderRadius: Radius.full,
+    borderWidth: 1,
+    borderColor: Colors.glassBorder,
+    paddingHorizontal: Spacing.three,
+    backgroundColor: Colors.glassRaised,
+  },
+  discoveryBadge: {
     minHeight: 32,
     alignItems: 'center',
     justifyContent: 'center',

--- a/matchify-app/src/lib/graphql/vote.ts
+++ b/matchify-app/src/lib/graphql/vote.ts
@@ -39,3 +39,27 @@ export const NEW_PROPOSAL_SUBSCRIPTION = gql`
     }
   }
 `
+
+export const NEXT_RECOMMENDATION_QUERY = gql`
+  query NextRecommendation($playlistId: String!, $excludedSpotifyTrackIds: [String!]) {
+    nextRecommendation(playlistId: $playlistId, excludedSpotifyTrackIds: $excludedSpotifyTrackIds) {
+      spotifyTrackId
+      title
+      artist
+      album
+      albumArtUrl
+      previewUrl
+      durationMs
+    }
+  }
+`
+
+export const RESPOND_TO_RECOMMENDATION_MUTATION = gql`
+  mutation RespondToRecommendation($playlistId: ID!, $spotifyTrackId: String!, $action: RecommendationAction!) {
+    respondToRecommendation(playlistId: $playlistId, spotifyTrackId: $spotifyTrackId, action: $action) {
+      id
+      status
+      likeCount
+    }
+  }
+`

--- a/matchify-backend/src/config.rs
+++ b/matchify-backend/src/config.rs
@@ -8,6 +8,7 @@ pub struct AppConfig {
     pub jwt_secret: String,
     pub spotify_client_id: String,
     pub spotify_client_secret: String,
+    pub lastfm_api_key: String,
 }
 
 fn validate_encryption_key(encryption_key: String) -> String {
@@ -39,6 +40,8 @@ impl AppConfig {
             std::env::var("SPOTIFY_CLIENT_ID").expect("SPOTIFY_CLIENT_ID must be set");
         let spotify_client_secret =
             std::env::var("SPOTIFY_CLIENT_SECRET").expect("SPOTIFY_CLIENT_SECRET must be set");
+        let lastfm_api_key = std::env::var("LASTFM_API_KEY")
+            .expect("LASTFM_API_KEY must be set for playlist recommendations");
 
         if jwt_secret.len() < 32 {
             panic!("JWT_SECRET must be at least 32 characters long");
@@ -51,6 +54,7 @@ impl AppConfig {
             jwt_secret,
             spotify_client_id,
             spotify_client_secret,
+            lastfm_api_key,
         }
     }
 }

--- a/matchify-backend/src/db/indexes.rs
+++ b/matchify-backend/src/db/indexes.rs
@@ -1,8 +1,4 @@
-use mongodb::{
-    bson::doc,
-    options::IndexOptions,
-    Database, IndexModel,
-};
+use mongodb::{Database, IndexModel, bson::doc, options::IndexOptions};
 
 pub async fn create_indexes(db: &Database) -> mongodb::error::Result<()> {
     // users
@@ -42,6 +38,23 @@ pub async fn create_indexes(db: &Database) -> mongodb::error::Result<()> {
         .build();
     db.collection::<mongodb::bson::Document>("votes")
         .create_index(vote_idx)
+        .await?;
+
+    // recommendations
+    let recommendation_cache_idx = IndexModel::builder()
+        .keys(doc! { "seed_key": 1 })
+        .options(IndexOptions::builder().unique(true).build())
+        .build();
+    db.collection::<mongodb::bson::Document>("recommendation_cache")
+        .create_index(recommendation_cache_idx)
+        .await?;
+
+    let recommendation_interaction_idx = IndexModel::builder()
+        .keys(doc! { "playlist_id": 1, "user_id": 1, "spotify_track_id": 1 })
+        .options(IndexOptions::builder().unique(true).build())
+        .build();
+    db.collection::<mongodb::bson::Document>("recommendation_interactions")
+        .create_index(recommendation_interaction_idx)
         .await?;
 
     tracing::info!("MongoDB indexes created or verified");

--- a/matchify-backend/src/graphql/mod.rs
+++ b/matchify-backend/src/graphql/mod.rs
@@ -13,12 +13,14 @@ pub fn build_schema(
     db: mongodb::Database,
     config: crate::config::AppConfig,
     spotify_client: crate::service::spotify::SpotifyClient,
+    lastfm_client: crate::service::lastfm::LastfmClient,
     event_broker: crate::events::EventBroker,
 ) -> AppSchema {
     Schema::build(Query, Mutation, MatchifySubscription)
         .data(db)
         .data(config)
         .data(spotify_client)
+        .data(lastfm_client)
         .data(event_broker)
         .finish()
 }

--- a/matchify-backend/src/graphql/mutation.rs
+++ b/matchify-backend/src/graphql/mutation.rs
@@ -1,9 +1,9 @@
 use async_graphql::{Context, InputObject, Object, SimpleObject};
 use chrono::{Duration, Utc};
 use mongodb::{
+    Database,
     bson::{doc, oid::ObjectId},
     options::{FindOneAndUpdateOptions, ReturnDocument},
-    Database,
 };
 
 use crate::{
@@ -61,12 +61,18 @@ impl Mutation {
         code: String,
         redirect_uri: String,
     ) -> Result<AuthPayload> {
-        let spotify_client = ctx.data::<SpotifyClient>().map_err(|_| AppError::Unexpected)?;
+        let spotify_client = ctx
+            .data::<SpotifyClient>()
+            .map_err(|_| AppError::Unexpected)?;
         let db = ctx.data::<Database>().map_err(|_| AppError::Unexpected)?;
-        let config = ctx.data::<crate::config::AppConfig>().map_err(|_| AppError::Unexpected)?;
+        let config = ctx
+            .data::<crate::config::AppConfig>()
+            .map_err(|_| AppError::Unexpected)?;
 
         let tokens = spotify_client.exchange_code(&code, &redirect_uri).await?;
-        let profile = spotify_client.get_user_profile(&tokens.access_token).await?;
+        let profile = spotify_client
+            .get_user_profile(&tokens.access_token)
+            .await?;
 
         let encrypted_access = encrypt_token(&tokens.access_token, &config.encryption_key)?;
         let encrypted_refresh = tokens
@@ -138,8 +144,7 @@ impl Mutation {
                 AppError::SpotifyAuth("You must be logged in to create a playlist".to_string())
             })?;
 
-        let owner_id = ObjectId::parse_str(&auth_user.user_id)
-            .map_err(|_| AppError::Unexpected)?;
+        let owner_id = ObjectId::parse_str(&auth_user.user_id).map_err(|_| AppError::Unexpected)?;
 
         let db = ctx.data::<Database>().map_err(|_| AppError::Unexpected)?;
 
@@ -157,19 +162,13 @@ impl Mutation {
         Ok(PlaylistGql::from(playlist))
     }
 
-    async fn join_playlist(
-        &self,
-        ctx: &Context<'_>,
-        invite_code: String,
-    ) -> Result<PlaylistGql> {
-        let auth_user = ctx
-            .data_opt::<AuthUser>()
-            .ok_or_else(|| {
-                AppError::SpotifyAuth("You must be logged in to join a playlist".to_string())
-            })?;
+    async fn join_playlist(&self, ctx: &Context<'_>, invite_code: String) -> Result<PlaylistGql> {
+        let auth_user = ctx.data_opt::<AuthUser>().ok_or_else(|| {
+            AppError::SpotifyAuth("You must be logged in to join a playlist".to_string())
+        })?;
 
-        let caller_id = ObjectId::parse_str(&auth_user.user_id)
-            .map_err(|_| AppError::Unexpected)?;
+        let caller_id =
+            ObjectId::parse_str(&auth_user.user_id).map_err(|_| AppError::Unexpected)?;
 
         let db = ctx.data::<Database>().map_err(|_| AppError::Unexpected)?;
 
@@ -188,8 +187,8 @@ impl Mutation {
             .data_opt::<AuthUser>()
             .ok_or_else(|| AppError::SpotifyAuth("UNAUTHENTICATED".to_string()))?;
 
-        let caller_id = ObjectId::parse_str(&auth_user.user_id)
-            .map_err(|_| AppError::Unexpected)?;
+        let caller_id =
+            ObjectId::parse_str(&auth_user.user_id).map_err(|_| AppError::Unexpected)?;
 
         let playlist_id = ObjectId::parse_str(&id)
             .map_err(|_| AppError::Validation("Invalid playlist ID format".to_string()))?;
@@ -211,17 +210,13 @@ impl Mutation {
         Ok(PlaylistGql::from(playlist))
     }
 
-    async fn leave_playlist(
-        &self,
-        ctx: &Context<'_>,
-        playlist_id: String,
-    ) -> Result<bool> {
+    async fn leave_playlist(&self, ctx: &Context<'_>, playlist_id: String) -> Result<bool> {
         let auth_user = ctx
             .data_opt::<AuthUser>()
             .ok_or_else(|| AppError::SpotifyAuth("UNAUTHENTICATED".to_string()))?;
 
-        let caller_id = ObjectId::parse_str(&auth_user.user_id)
-            .map_err(|_| AppError::Unexpected)?;
+        let caller_id =
+            ObjectId::parse_str(&auth_user.user_id).map_err(|_| AppError::Unexpected)?;
 
         let pid = ObjectId::parse_str(&playlist_id)
             .map_err(|_| AppError::Validation("Invalid playlist ID format".to_string()))?;
@@ -241,12 +236,12 @@ impl Mutation {
             .data_opt::<AuthUser>()
             .ok_or_else(|| AppError::SpotifyAuth("UNAUTHENTICATED".to_string()))?;
 
-        let caller_id = ObjectId::parse_str(&auth_user.user_id)
-            .map_err(|_| AppError::Unexpected)?;
+        let caller_id =
+            ObjectId::parse_str(&auth_user.user_id).map_err(|_| AppError::Unexpected)?;
 
         let db = ctx.data::<Database>().map_err(|_| AppError::Unexpected)?;
         let collection = db.collection::<User>("users");
-        
+
         let user = collection
             .find_one(doc! { "_id": caller_id })
             .await
@@ -256,12 +251,14 @@ impl Mutation {
         let spotify_client = ctx
             .data::<crate::service::spotify::SpotifyClient>()
             .map_err(|_| AppError::Unexpected)?;
-            
+
         let config = ctx
             .data::<crate::config::AppConfig>()
             .map_err(|_| AppError::Unexpected)?;
 
-        let access_token = crate::service::spotify::get_valid_access_token(&user, spotify_client, db, config).await?;
+        let access_token =
+            crate::service::spotify::get_valid_access_token(&user, spotify_client, db, config)
+                .await?;
 
         let pid = ObjectId::parse_str(&playlist_id)
             .map_err(|_| AppError::Validation("Invalid playlist ID format".to_string()))?;
@@ -277,7 +274,10 @@ impl Mutation {
         )
         .await?;
 
-        Ok(songs.into_iter().map(crate::model::song::SongGql::from).collect())
+        Ok(songs
+            .into_iter()
+            .map(crate::model::song::SongGql::from)
+            .collect())
     }
 
     async fn vote_on_track(
@@ -290,8 +290,8 @@ impl Mutation {
             .data_opt::<AuthUser>()
             .ok_or_else(|| AppError::SpotifyAuth("UNAUTHENTICATED".to_string()))?;
 
-        let caller_id = ObjectId::parse_str(&auth_user.user_id)
-            .map_err(|_| AppError::Unexpected)?;
+        let caller_id =
+            ObjectId::parse_str(&auth_user.user_id).map_err(|_| AppError::Unexpected)?;
 
         let db = ctx.data::<Database>().map_err(|_| AppError::Unexpected)?;
         let client = db.client();
@@ -332,16 +332,16 @@ impl Mutation {
             .data_opt::<AuthUser>()
             .ok_or_else(|| AppError::SpotifyAuth("UNAUTHENTICATED".to_string()))?;
 
-        let caller_id = ObjectId::parse_str(&auth_user.user_id)
-            .map_err(|_| AppError::Unexpected)?;
+        let caller_id =
+            ObjectId::parse_str(&auth_user.user_id).map_err(|_| AppError::Unexpected)?;
 
         let db = ctx.data::<Database>().map_err(|_| AppError::Unexpected)?;
-        
+
         let p_id = ObjectId::parse_str(playlist_id.as_str())
             .map_err(|_| AppError::Validation("Invalid playlist ID format".to_string()))?;
-            
+
         let collection = db.collection::<User>("users");
-        
+
         let user = collection
             .find_one(doc! { "_id": caller_id })
             .await
@@ -351,12 +351,14 @@ impl Mutation {
         let spotify_client = ctx
             .data::<crate::service::spotify::SpotifyClient>()
             .map_err(|_| AppError::Unexpected)?;
-            
+
         let config = ctx
             .data::<crate::config::AppConfig>()
             .map_err(|_| AppError::Unexpected)?;
 
-        let access_token = crate::service::spotify::get_valid_access_token(&user, spotify_client, db, config).await?;
+        let access_token =
+            crate::service::spotify::get_valid_access_token(&user, spotify_client, db, config)
+                .await?;
 
         let song = crate::service::song::propose_track(
             db,
@@ -370,5 +372,58 @@ impl Mutation {
         .await?;
 
         Ok(crate::model::song::SongGql::from(song))
+    }
+
+    async fn respond_to_recommendation(
+        &self,
+        ctx: &Context<'_>,
+        playlist_id: async_graphql::ID,
+        spotify_track_id: String,
+        action: crate::model::recommendation::RecommendationAction,
+    ) -> Result<Option<crate::model::song::SongGql>> {
+        let auth_user = ctx
+            .data_opt::<AuthUser>()
+            .ok_or_else(|| AppError::SpotifyAuth("UNAUTHENTICATED".to_string()))?;
+
+        let caller_id =
+            ObjectId::parse_str(&auth_user.user_id).map_err(|_| AppError::Unexpected)?;
+
+        let p_id = ObjectId::parse_str(playlist_id.as_str())
+            .map_err(|_| AppError::Validation("Invalid playlist ID format".to_string()))?;
+
+        let db = ctx.data::<Database>().map_err(|_| AppError::Unexpected)?;
+        let collection = db.collection::<User>("users");
+        let user = collection
+            .find_one(doc! { "_id": caller_id })
+            .await
+            .map_err(AppError::Database)?
+            .ok_or_else(|| AppError::SpotifyAuth("UNAUTHENTICATED".to_string()))?;
+
+        let spotify_client = ctx
+            .data::<crate::service::spotify::SpotifyClient>()
+            .map_err(|_| AppError::Unexpected)?;
+        let config = ctx
+            .data::<crate::config::AppConfig>()
+            .map_err(|_| AppError::Unexpected)?;
+
+        let access_token =
+            crate::service::spotify::get_valid_access_token(&user, spotify_client, db, config)
+                .await?;
+
+        let song = crate::service::recommendation::respond_to_recommendation(
+            db.client(),
+            db,
+            p_id,
+            caller_id,
+            spotify_track_id,
+            action,
+            spotify_client,
+            &access_token,
+            ctx.data_unchecked::<crate::events::EventBroker>(),
+            config,
+        )
+        .await?;
+
+        Ok(song.map(crate::model::song::SongGql::from))
     }
 }

--- a/matchify-backend/src/graphql/query.rs
+++ b/matchify-backend/src/graphql/query.rs
@@ -1,14 +1,11 @@
 use async_graphql::{Context, Object, Result as GraphqlResult};
-use mongodb::{bson::doc, Database};
+use mongodb::{Database, bson::doc};
 use std::str::FromStr;
 
 use crate::{
     error::{AppError, Result},
     jwt::AuthUser,
-    model::{
-        playlist::PlaylistGql,
-        user::User,
-    },
+    model::{playlist::PlaylistGql, user::User},
     service::playlist as playlist_service,
 };
 
@@ -165,7 +162,7 @@ impl Query {
             .map_err(|_| AppError::Unexpected)?;
 
         let db = ctx.data::<Database>().map_err(|_| AppError::Unexpected)?;
-        
+
         let collection = db.collection::<User>("users");
         let user = collection
             .find_one(doc! { "_id": object_id })
@@ -176,17 +173,70 @@ impl Query {
         let spotify_client = ctx
             .data::<crate::service::spotify::SpotifyClient>()
             .map_err(|_| AppError::Unexpected)?;
-            
+
         let config = ctx
             .data::<crate::config::AppConfig>()
             .map_err(|_| AppError::Unexpected)?;
 
-        let access_token = crate::service::spotify::get_valid_access_token(&user, spotify_client, db, config).await?;
+        let access_token =
+            crate::service::spotify::get_valid_access_token(&user, spotify_client, db, config)
+                .await?;
 
         let actual_limit = limit.unwrap_or(20);
-        let tracks = spotify_client.search_tracks(&query, actual_limit, &access_token).await?;
+        let tracks = spotify_client
+            .search_tracks(&query, actual_limit, &access_token)
+            .await?;
 
         Ok(tracks)
     }
 
+    async fn next_recommendation(
+        &self,
+        ctx: &Context<'_>,
+        playlist_id: String,
+        excluded_spotify_track_ids: Option<Vec<String>>,
+    ) -> Result<Option<crate::model::spotify::SpotifyTrack>> {
+        let auth_user = ctx
+            .data_opt::<AuthUser>()
+            .ok_or_else(|| AppError::SpotifyAuth("UNAUTHENTICATED".to_string()))?;
+
+        let caller_id = mongodb::bson::oid::ObjectId::from_str(&auth_user.user_id)
+            .map_err(|_| AppError::Unexpected)?;
+
+        let p_id = mongodb::bson::oid::ObjectId::from_str(&playlist_id)
+            .map_err(|_| AppError::Validation("Invalid playlist ID format".to_string()))?;
+
+        let db = ctx.data::<Database>().map_err(|_| AppError::Unexpected)?;
+        let users = db.collection::<User>("users");
+        let user = users
+            .find_one(doc! { "_id": caller_id })
+            .await
+            .map_err(AppError::Database)?
+            .ok_or_else(|| AppError::SpotifyAuth("UNAUTHENTICATED".to_string()))?;
+
+        let spotify_client = ctx
+            .data::<crate::service::spotify::SpotifyClient>()
+            .map_err(|_| AppError::Unexpected)?;
+        let lastfm_client = ctx
+            .data::<crate::service::lastfm::LastfmClient>()
+            .map_err(|_| AppError::Unexpected)?;
+        let config = ctx
+            .data::<crate::config::AppConfig>()
+            .map_err(|_| AppError::Unexpected)?;
+
+        let access_token =
+            crate::service::spotify::get_valid_access_token(&user, spotify_client, db, config)
+                .await?;
+
+        crate::service::recommendation::next_recommendation(
+            db,
+            p_id,
+            caller_id,
+            excluded_spotify_track_ids.as_deref().unwrap_or(&[]),
+            lastfm_client,
+            spotify_client,
+            &access_token,
+        )
+        .await
+    }
 }

--- a/matchify-backend/src/main.rs
+++ b/matchify-backend/src/main.rs
@@ -71,12 +71,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     tracing::info!("Successfully initialized Spotify Client");
 
+    tracing::info!("Initializing Last.fm Client");
+    let lastfm_client = service::lastfm::LastfmClient::new(config.lastfm_api_key.clone());
+    tracing::info!("Successfully initialized Last.fm Client");
+
     tracing::info!("Initializing Event Broker");
     let event_broker = events::EventBroker::new();
     tracing::info!("Successfully initialized Event Broker");
 
     tracing::info!("Building GraphQL Schema");
-    let schema = graphql::build_schema(db, config.clone(), spotify_client, event_broker.clone());
+    let schema = graphql::build_schema(
+        db,
+        config.clone(),
+        spotify_client,
+        lastfm_client,
+        event_broker.clone(),
+    );
     tracing::info!("Successfully built GraphQL Schema");
 
     tracing::info!("Building Axum Router");

--- a/matchify-backend/src/model/mod.rs
+++ b/matchify-backend/src/model/mod.rs
@@ -1,12 +1,17 @@
-pub mod user;
 pub mod playlist;
+pub mod recommendation;
 pub mod song;
-pub mod vote;
 pub mod spotify;
 pub mod stats;
+pub mod user;
+pub mod vote;
 
-pub use user::User;
 pub use playlist::{Playlist, PlaylistGql};
+pub use recommendation::{
+    RecommendationAction, RecommendationCacheEntry, RecommendationCandidate,
+    RecommendationInteraction,
+};
 pub use song::{Song, SongGql, TrackStatus};
+pub use stats::{MemberStat, PlaylistStats};
+pub use user::User;
 pub use vote::{Vote, VoteType};
-pub use stats::{PlaylistStats, MemberStat};

--- a/matchify-backend/src/model/recommendation.rs
+++ b/matchify-backend/src/model/recommendation.rs
@@ -1,0 +1,62 @@
+use async_graphql::Enum;
+use chrono::{DateTime, Utc};
+use mongodb::bson::oid::ObjectId;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Enum)]
+pub enum RecommendationAction {
+    Accept,
+    Reject,
+}
+
+impl std::fmt::Display for RecommendationAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RecommendationAction::Accept => write!(f, "Accept"),
+            RecommendationAction::Reject => write!(f, "Reject"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecommendationCandidate {
+    pub title: String,
+    pub artist: String,
+    pub match_score: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecommendationCacheEntry {
+    #[serde(rename = "_id")]
+    pub id: ObjectId,
+    pub seed_key: String,
+    pub seed_artist: String,
+    pub seed_title: String,
+    pub candidates: Vec<RecommendationCandidate>,
+    #[serde(with = "mongodb::bson::serde_helpers::chrono_datetime_as_bson_datetime")]
+    pub fetched_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecommendationInteraction {
+    #[serde(rename = "_id")]
+    pub id: ObjectId,
+    pub playlist_id: ObjectId,
+    pub user_id: ObjectId,
+    pub spotify_track_id: String,
+    pub track_key: String,
+    pub action: RecommendationAction,
+    #[serde(with = "mongodb::bson::serde_helpers::chrono_datetime_as_bson_datetime")]
+    pub created_at: DateTime<Utc>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_recommendation_action_for_graphql() {
+        assert_eq!(RecommendationAction::Accept.to_string(), "Accept");
+        assert_eq!(RecommendationAction::Reject.to_string(), "Reject");
+    }
+}

--- a/matchify-backend/src/service/lastfm.rs
+++ b/matchify-backend/src/service/lastfm.rs
@@ -1,0 +1,158 @@
+use crate::error::{AppError, Result};
+use crate::model::recommendation::RecommendationCandidate;
+use reqwest::Client;
+use serde::Deserialize;
+
+#[derive(Clone)]
+pub struct LastfmClient {
+    api_key: String,
+    client: Client,
+    base_url: String,
+}
+
+impl LastfmClient {
+    pub fn new(api_key: String) -> Self {
+        Self {
+            api_key,
+            client: Client::new(),
+            base_url: "https://ws.audioscrobbler.com".to_string(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_base_url(api_key: String, base_url: String) -> Self {
+        Self {
+            api_key,
+            client: Client::new(),
+            base_url,
+        }
+    }
+
+    pub async fn similar_tracks(
+        &self,
+        artist: &str,
+        track: &str,
+        limit: u32,
+    ) -> Result<Vec<RecommendationCandidate>> {
+        let actual_limit = limit.clamp(1, 50);
+        let url = format!("{}/2.0/", self.base_url);
+        let response = self
+            .client
+            .get(&url)
+            .query(&[
+                ("method", "track.getsimilar"),
+                ("artist", artist),
+                ("track", track),
+                ("api_key", &self.api_key),
+                ("format", "json"),
+                ("autocorrect", "1"),
+                ("limit", &actual_limit.to_string()),
+            ])
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            return Err(AppError::Validation(format!(
+                "Last.fm similar tracks failed ({}): {}",
+                status, error_text
+            )));
+        }
+
+        let body = response.text().await?;
+        parse_similar_tracks_response(&body)
+    }
+}
+
+#[derive(Deserialize)]
+struct LastfmSimilarTracksResponse {
+    similartracks: LastfmSimilarTracks,
+}
+
+#[derive(Deserialize)]
+struct LastfmSimilarTracks {
+    #[serde(default)]
+    track: Vec<LastfmSimilarTrack>,
+}
+
+#[derive(Deserialize)]
+struct LastfmSimilarTrack {
+    name: String,
+    artist: LastfmArtist,
+    #[serde(rename = "match", deserialize_with = "deserialize_match_score")]
+    match_score: f64,
+}
+
+#[derive(Deserialize)]
+struct LastfmArtist {
+    name: String,
+}
+
+fn deserialize_match_score<'de, D>(deserializer: D) -> std::result::Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum MatchValue {
+        Number(f64),
+        String(String),
+    }
+
+    match MatchValue::deserialize(deserializer)? {
+        MatchValue::Number(value) => Ok(value),
+        MatchValue::String(value) => value.parse::<f64>().map_err(serde::de::Error::custom),
+    }
+}
+
+pub fn parse_similar_tracks_response(body: &str) -> Result<Vec<RecommendationCandidate>> {
+    let response: LastfmSimilarTracksResponse =
+        serde_json::from_str(body).map_err(|_| AppError::Unexpected)?;
+
+    Ok(response
+        .similartracks
+        .track
+        .into_iter()
+        .filter(|track| !track.name.trim().is_empty() && !track.artist.name.trim().is_empty())
+        .map(|track| RecommendationCandidate {
+            title: track.name,
+            artist: track.artist.name,
+            match_score: track.match_score,
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_similar_tracks_response() {
+        let body = r#"{
+            "similartracks": {
+                "track": [
+                    {
+                        "name": "Ray of Light",
+                        "match": "10.95",
+                        "artist": { "name": "Madonna" }
+                    },
+                    {
+                        "name": "Frozen",
+                        "match": 8.5,
+                        "artist": { "name": "Madonna" }
+                    }
+                ]
+            }
+        }"#;
+
+        let tracks = parse_similar_tracks_response(body).expect("response should parse");
+
+        assert_eq!(tracks.len(), 2);
+        assert_eq!(tracks[0].title, "Ray of Light");
+        assert_eq!(tracks[0].artist, "Madonna");
+        assert_eq!(tracks[0].match_score, 10.95);
+        assert_eq!(tracks[1].title, "Frozen");
+        assert_eq!(tracks[1].match_score, 8.5);
+    }
+}

--- a/matchify-backend/src/service/mod.rs
+++ b/matchify-backend/src/service/mod.rs
@@ -1,4 +1,6 @@
-pub mod spotify;
+pub mod lastfm;
 pub mod playlist;
+pub mod recommendation;
 pub mod song;
+pub mod spotify;
 pub mod stats;

--- a/matchify-backend/src/service/recommendation.rs
+++ b/matchify-backend/src/service/recommendation.rs
@@ -1,0 +1,465 @@
+use crate::config::AppConfig;
+use crate::error::{AppError, Result};
+use crate::model::playlist::Playlist;
+use crate::model::recommendation::{
+    RecommendationAction, RecommendationCacheEntry, RecommendationCandidate,
+    RecommendationInteraction,
+};
+use crate::model::song::Song;
+use crate::model::spotify::SpotifyTrack;
+use crate::model::vote::VoteType;
+use crate::service::lastfm::LastfmClient;
+use crate::service::song;
+use crate::service::spotify::SpotifyClient;
+use chrono::{DateTime, Duration, Utc};
+use futures::TryStreamExt;
+use mongodb::{
+    Client, Database,
+    bson::{doc, oid::ObjectId},
+};
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+
+const CACHE_TTL_DAYS: i64 = 7;
+const SEED_LIMIT: i64 = 10;
+const SIMILAR_TRACK_LIMIT: u32 = 20;
+const SPOTIFY_RESOLUTION_LIMIT: usize = 30;
+
+#[derive(Debug, Clone)]
+pub struct ScoredCandidateInput {
+    pub candidate: RecommendationCandidate,
+    pub seed_key: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ScoredRecommendationCandidate {
+    pub title: String,
+    pub artist: String,
+    pub score: f64,
+    pub seed_count: usize,
+}
+
+#[derive(Debug)]
+struct CandidateAggregate {
+    title: String,
+    artist: String,
+    score: f64,
+    seed_keys: HashSet<String>,
+}
+
+pub fn normalize_track_key(artist: &str, title: &str) -> String {
+    format!(
+        "{}::{}",
+        normalize_key_part(artist),
+        normalize_key_part(title)
+    )
+}
+
+fn normalize_key_part(value: &str) -> String {
+    value
+        .trim()
+        .to_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+pub fn is_cache_fresh(fetched_at: DateTime<Utc>) -> bool {
+    fetched_at > Utc::now() - Duration::days(CACHE_TTL_DAYS)
+}
+
+pub fn score_candidates(
+    inputs: Vec<ScoredCandidateInput>,
+    existing_track_keys: &HashSet<String>,
+    rejected_track_keys: &HashSet<String>,
+    playlist_artist_counts: &HashMap<String, usize>,
+) -> Vec<ScoredRecommendationCandidate> {
+    let mut aggregates: HashMap<String, CandidateAggregate> = HashMap::new();
+
+    for input in inputs {
+        let key = normalize_track_key(&input.candidate.artist, &input.candidate.title);
+
+        if existing_track_keys.contains(&key) || rejected_track_keys.contains(&key) {
+            continue;
+        }
+
+        let aggregate = aggregates.entry(key).or_insert_with(|| CandidateAggregate {
+            title: input.candidate.title.clone(),
+            artist: input.candidate.artist.clone(),
+            score: 0.0,
+            seed_keys: HashSet::new(),
+        });
+
+        aggregate.score += input.candidate.match_score;
+        aggregate.seed_keys.insert(input.seed_key);
+    }
+
+    let mut scored = aggregates
+        .into_values()
+        .map(|aggregate| {
+            let seed_count = aggregate.seed_keys.len();
+            let duplicate_artist_penalty = playlist_artist_counts
+                .get(&normalize_key_part(&aggregate.artist))
+                .copied()
+                .unwrap_or(0) as f64
+                * 0.5;
+            ScoredRecommendationCandidate {
+                title: aggregate.title,
+                artist: aggregate.artist,
+                score: aggregate.score + seed_count.saturating_sub(1) as f64 * 4.0
+                    - duplicate_artist_penalty,
+                seed_count,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    scored.sort_by(|left, right| {
+        right
+            .score
+            .partial_cmp(&left.score)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| right.seed_count.cmp(&left.seed_count))
+            .then_with(|| left.artist.cmp(&right.artist))
+            .then_with(|| left.title.cmp(&right.title))
+    });
+
+    scored
+}
+
+pub async fn next_recommendation(
+    db: &Database,
+    playlist_id: ObjectId,
+    user_id: ObjectId,
+    excluded_spotify_track_ids: &[String],
+    lastfm_client: &LastfmClient,
+    spotify_client: &SpotifyClient,
+    spotify_access_token: &str,
+) -> Result<Option<SpotifyTrack>> {
+    let playlist = find_member_playlist(db, playlist_id, user_id).await?;
+    let seeds = recommendation_seeds(db, playlist.id).await?;
+
+    if seeds.is_empty() {
+        return Ok(None);
+    }
+
+    let (existing_track_keys, playlist_artist_counts) =
+        existing_track_keys_and_artist_counts(db, playlist.id).await?;
+    let rejected_track_keys = rejected_track_keys(db, playlist.id, user_id).await?;
+    let excluded_spotify_track_ids = excluded_spotify_track_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<HashSet<_>>();
+    let mut inputs = Vec::new();
+
+    for seed in seeds {
+        let seed_key = normalize_track_key(&seed.artist, &seed.title);
+        let candidates = cached_or_fetch_candidates(db, lastfm_client, &seed).await?;
+
+        inputs.extend(
+            candidates
+                .into_iter()
+                .map(|candidate| ScoredCandidateInput {
+                    candidate,
+                    seed_key: seed_key.clone(),
+                }),
+        );
+    }
+
+    let scored = score_candidates(
+        inputs,
+        &existing_track_keys,
+        &rejected_track_keys,
+        &playlist_artist_counts,
+    );
+
+    for candidate in scored.into_iter().take(SPOTIFY_RESOLUTION_LIMIT) {
+        let query = format!(
+            "track:\"{}\" artist:\"{}\"",
+            candidate.title, candidate.artist
+        );
+        let tracks = spotify_client
+            .search_tracks(&query, 1, spotify_access_token)
+            .await?;
+
+        if let Some(track) = tracks.into_iter().next() {
+            let spotify_key = normalize_track_key(&track.artist, &track.title);
+            if !excluded_spotify_track_ids.contains(track.spotify_track_id.as_str())
+                && !existing_track_keys.contains(&spotify_key)
+                && !rejected_track_keys.contains(&spotify_key)
+            {
+                return Ok(Some(track));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+pub async fn respond_to_recommendation(
+    client: &Client,
+    db: &Database,
+    playlist_id: ObjectId,
+    user_id: ObjectId,
+    spotify_track_id: String,
+    action: RecommendationAction,
+    spotify_client: &SpotifyClient,
+    spotify_access_token: &str,
+    broker: &crate::events::EventBroker,
+    config: &AppConfig,
+) -> Result<Option<Song>> {
+    find_member_playlist(db, playlist_id, user_id).await?;
+    let spotify_tracks = spotify_client
+        .get_tracks(&[spotify_track_id.clone()], spotify_access_token)
+        .await?;
+    let spotify_track = spotify_tracks.into_iter().next().ok_or_else(|| {
+        AppError::NotFound(format!("Spotify track {} not found", spotify_track_id))
+    })?;
+    let track_key = normalize_track_key(&spotify_track.artist, &spotify_track.title);
+
+    record_interaction(
+        db,
+        playlist_id,
+        user_id,
+        &spotify_track_id,
+        &track_key,
+        action,
+    )
+    .await?;
+
+    if action == RecommendationAction::Reject {
+        return Ok(None);
+    }
+
+    let song = song::propose_track(
+        db,
+        playlist_id,
+        user_id,
+        spotify_track_id,
+        spotify_client,
+        spotify_access_token,
+        broker,
+    )
+    .await?;
+    let voted_song = song::vote_on_track(
+        client,
+        db,
+        song.id,
+        user_id,
+        VoteType::Like,
+        broker,
+        spotify_client,
+        config,
+    )
+    .await?;
+
+    Ok(Some(voted_song))
+}
+
+async fn find_member_playlist(
+    db: &Database,
+    playlist_id: ObjectId,
+    user_id: ObjectId,
+) -> Result<Playlist> {
+    let playlists = db.collection::<Playlist>("playlists");
+    let playlist = playlists
+        .find_one(doc! { "_id": playlist_id })
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("Playlist {} not found", playlist_id)))?;
+
+    if !playlist.member_ids.contains(&user_id) {
+        return Err(AppError::Forbidden(
+            "You are not a member of this playlist".to_string(),
+        ));
+    }
+
+    Ok(playlist)
+}
+
+async fn recommendation_seeds(db: &Database, playlist_id: ObjectId) -> Result<Vec<Song>> {
+    let songs = db.collection::<Song>("songs");
+    let cursor = songs
+        .find(doc! {
+            "playlist_id": playlist_id,
+            "status": { "$in": ["Approved", "Pending"] },
+        })
+        .sort(doc! { "created_at": -1 })
+        .limit(SEED_LIMIT)
+        .await?;
+
+    cursor.try_collect().await.map_err(AppError::Database)
+}
+
+async fn existing_track_keys_and_artist_counts(
+    db: &Database,
+    playlist_id: ObjectId,
+) -> Result<(HashSet<String>, HashMap<String, usize>)> {
+    let songs = db.collection::<Song>("songs");
+    let cursor = songs.find(doc! { "playlist_id": playlist_id }).await?;
+    let existing: Vec<Song> = cursor.try_collect().await.map_err(AppError::Database)?;
+    let mut track_keys = HashSet::new();
+    let mut artist_counts = HashMap::new();
+
+    for song in existing {
+        track_keys.insert(normalize_track_key(&song.artist, &song.title));
+        *artist_counts
+            .entry(normalize_key_part(&song.artist))
+            .or_insert(0) += 1;
+    }
+
+    Ok((track_keys, artist_counts))
+}
+
+async fn rejected_track_keys(
+    db: &Database,
+    playlist_id: ObjectId,
+    user_id: ObjectId,
+) -> Result<HashSet<String>> {
+    let interactions = db.collection::<RecommendationInteraction>("recommendation_interactions");
+    let cursor = interactions
+        .find(doc! {
+            "playlist_id": playlist_id,
+            "user_id": user_id,
+            "action": "Reject",
+        })
+        .await?;
+    let rejected: Vec<RecommendationInteraction> =
+        cursor.try_collect().await.map_err(AppError::Database)?;
+
+    Ok(rejected
+        .into_iter()
+        .map(|interaction| interaction.track_key)
+        .collect())
+}
+
+async fn cached_or_fetch_candidates(
+    db: &Database,
+    lastfm_client: &LastfmClient,
+    seed: &Song,
+) -> Result<Vec<RecommendationCandidate>> {
+    let cache = db.collection::<RecommendationCacheEntry>("recommendation_cache");
+    let seed_key = normalize_track_key(&seed.artist, &seed.title);
+
+    if let Some(entry) = cache.find_one(doc! { "seed_key": &seed_key }).await? {
+        if is_cache_fresh(entry.fetched_at) {
+            return Ok(entry.candidates);
+        }
+    }
+
+    let candidates = lastfm_client
+        .similar_tracks(&seed.artist, &seed.title, SIMILAR_TRACK_LIMIT)
+        .await?;
+    let entry = RecommendationCacheEntry {
+        id: ObjectId::new(),
+        seed_key: seed_key.clone(),
+        seed_artist: seed.artist.clone(),
+        seed_title: seed.title.clone(),
+        candidates: candidates.clone(),
+        fetched_at: Utc::now(),
+    };
+
+    cache
+        .replace_one(doc! { "seed_key": &seed_key }, &entry)
+        .upsert(true)
+        .await?;
+
+    Ok(candidates)
+}
+
+async fn record_interaction(
+    db: &Database,
+    playlist_id: ObjectId,
+    user_id: ObjectId,
+    spotify_track_id: &str,
+    track_key: &str,
+    action: RecommendationAction,
+) -> Result<()> {
+    let interactions = db.collection::<RecommendationInteraction>("recommendation_interactions");
+    let interaction = RecommendationInteraction {
+        id: ObjectId::new(),
+        playlist_id,
+        user_id,
+        spotify_track_id: spotify_track_id.to_string(),
+        track_key: track_key.to_string(),
+        action,
+        created_at: Utc::now(),
+    };
+
+    interactions
+        .replace_one(
+            doc! {
+                "playlist_id": playlist_id,
+                "user_id": user_id,
+                "spotify_track_id": spotify_track_id,
+            },
+            &interaction,
+        )
+        .upsert(true)
+        .await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::recommendation::RecommendationCandidate;
+    use chrono::{Duration, Utc};
+    use std::collections::{HashMap, HashSet};
+
+    fn candidate(
+        title: &str,
+        artist: &str,
+        match_score: f64,
+        seed_key: &str,
+    ) -> ScoredCandidateInput {
+        ScoredCandidateInput {
+            candidate: RecommendationCandidate {
+                title: title.to_string(),
+                artist: artist.to_string(),
+                match_score,
+            },
+            seed_key: seed_key.to_string(),
+        }
+    }
+
+    #[test]
+    fn scoring_prefers_candidates_that_match_multiple_seeds() {
+        let scored = score_candidates(
+            vec![
+                candidate("Shared", "Artist A", 6.0, "seed-1"),
+                candidate("Shared", "Artist A", 6.0, "seed-2"),
+                candidate("Single", "Artist B", 10.0, "seed-3"),
+            ],
+            &HashSet::new(),
+            &HashSet::new(),
+            &HashMap::new(),
+        );
+
+        assert_eq!(scored[0].title, "Shared");
+    }
+
+    #[test]
+    fn scoring_excludes_existing_and_rejected_tracks() {
+        let existing = HashSet::from([normalize_track_key("Artist A", "Existing")]);
+        let rejected = HashSet::from([normalize_track_key("Artist B", "Rejected")]);
+        let scored = score_candidates(
+            vec![
+                candidate("Existing", "Artist A", 10.0, "seed-1"),
+                candidate("Rejected", "Artist B", 9.0, "seed-1"),
+                candidate("Fresh", "Artist C", 5.0, "seed-1"),
+            ],
+            &existing,
+            &rejected,
+            &HashMap::new(),
+        );
+
+        assert_eq!(scored.len(), 1);
+        assert_eq!(scored[0].title, "Fresh");
+    }
+
+    #[test]
+    fn cache_entry_is_fresh_for_seven_days() {
+        assert!(is_cache_fresh(Utc::now() - Duration::days(6)));
+        assert!(!is_cache_fresh(Utc::now() - Duration::days(8)));
+    }
+}


### PR DESCRIPTION
## Summary
- Add Last.fm-backed playlist discovery after the normal proposal queue
- Let users swipe recommended tracks, record accepts/rejects, and avoid repeats
- Reuse the existing vote transaction on accept so threshold approval and Spotify sync still happen

## Testing
- Added backend unit coverage for recommendation parsing, scoring, cache freshness, and accept handling
- Verified backend compiles and targeted recommendation tests pass
- Performed UI type-checking and linting; only existing generated GraphQL warnings remain